### PR TITLE
Overhaul trading pagination and add auto-refresh polling

### DIFF
--- a/css/trading.css
+++ b/css/trading.css
@@ -684,14 +684,20 @@ content: '';
     transform: translateY(-1px);
 }
 
-/* Load more */
-.load-more-container {
-    text-align: center;
+/* Numbered pagination */
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
     padding: 1.5rem 0;
 }
 
-.btn-load-more {
-    padding: 0.65rem 2rem;
+.page-btn {
+    min-width: 38px;
+    height: 38px;
+    padding: 0 0.6rem;
     background: var(--bg-item);
     border: 1px solid var(--border-color);
     border-radius: 10px;
@@ -703,9 +709,27 @@ content: '';
     font-family: inherit;
 }
 
-.btn-load-more:hover {
+.page-btn:hover:not(:disabled):not(.active) {
     background: var(--bg-item-hover);
     border-color: var(--accent);
+}
+
+.page-btn.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: white;
+    cursor: default;
+}
+
+.page-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.page-ellipsis {
+    padding: 0 0.25rem;
+    opacity: 0.6;
+    user-select: none;
 }
 
 /* Skeleton loader */
@@ -1762,6 +1786,99 @@ content: '';
 
 .modal-inner {
     padding: 1.25rem;
+}
+
+/* Make Offer modal */
+#makeOfferModal .modal-compact {
+    max-width: 480px;
+}
+
+/* The header carries the listing title — keep long ones on one line. */
+#makeOfferModal .modal-header h3 {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.modal-inner .field {
+    margin-bottom: 1.25rem;
+}
+
+.modal-inner .field > label {
+    display: block;
+    font-size: 0.775rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+    color: CanvasText;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.item-search-wrapper {
+    position: relative;
+    margin-bottom: 0.6rem;
+}
+
+.item-search-input {
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    background: var(--bg-item);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: CanvasText;
+    font-size: 0.875rem;
+    font-family: inherit;
+    transition: all 0.2s;
+    min-height: 40px;
+}
+
+.item-search-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+/* Results float over the modal content like the other search dropdowns. */
+.search-results {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: 4px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    max-height: 260px;
+    overflow-y: auto;
+    z-index: 100;
+    display: none;
+    box-shadow: 0 8px 24px var(--shadow-color);
+}
+
+.search-results.active {
+    display: block;
+}
+
+.modal-inner .selected-items {
+    margin-bottom: 0.6rem;
+}
+
+.modal-inner textarea {
+    padding: 0.6rem 0.75rem;
+    background: var(--bg-item);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: CanvasText;
+    font-size: 0.875rem;
+    font-family: inherit;
+    transition: all 0.2s;
+}
+
+.modal-inner textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .type-toggle {

--- a/functions/api/trades/_utils/helpers.js
+++ b/functions/api/trades/_utils/helpers.js
@@ -1,3 +1,29 @@
+// Canonical form of a user id: a plain digit string.
+// Historic rows (and any id that round-tripped through a D1 number bind) can
+// carry a float artifact ("137377499.0") because the trade tables store ids as
+// TEXT while `users.user_id` is INTEGER — D1 sends JS numbers as doubles, and
+// TEXT affinity stringifies them with the trailing ".0". Every id that gets
+// bound into a query or compared must go through here.
+export function normalizeUserId(id) {
+    if (id === null || id === undefined) return null;
+    return String(id).replace(/\.0+$/, '');
+}
+
+// The two forms a user id may take in legacy TEXT columns: clean ("123") and
+// float-artifact ("123.0"). Spread into `col IN (?, ?)` so reads keep working
+// on any rows written before the normalization fix / data cleanup.
+export function userIdForms(id) {
+    const clean = normalizeUserId(id);
+    return [clean, `${clean}.0`];
+}
+
+// True when two user ids refer to the same user, regardless of which historic
+// encoding (number, "123", "123.0") each side carries.
+export function isSameUser(a, b) {
+    if (a === null || a === undefined || b === null || b === undefined) return false;
+    return normalizeUserId(a) === normalizeUserId(b);
+}
+
 // Authenticate user from request.
 // Validates the opaque session token against the `sessions` table, matching the
 // scheme used by the rest of the site (see api/auth). The single JOIN to `users`
@@ -18,6 +44,7 @@ export async function authenticateUser(request, env) {
         WHERE s.token = ? AND s.expires_at > ?
     `).bind(token, Date.now()).first();
 
+    if (user) user.user_id = normalizeUserId(user.user_id);
     return user || null;
 }
 
@@ -70,26 +97,28 @@ export function validateFields(data, requiredFields) {
 export async function createNotification(env, userId, type, title, message, link = null) {
     await env.DBA.prepare(
         'INSERT INTO trade_notifications (user_id, type, title, message, link, created_at) VALUES (?, ?, ?, ?, ?, ?)'
-    ).bind(userId, type, title, message, link, Date.now()).run();
+    ).bind(normalizeUserId(userId), type, title, message, link, Date.now()).run();
 }
 
 // Update user trade stats
-export async function updateUserStats(env, userId) {
+export async function updateUserStats(env, rawUserId) {
+    const userId = normalizeUserId(rawUserId);
+    const forms = userIdForms(userId);
     const stats = await env.DBA.prepare(`
         SELECT
             COUNT(*) as total_trades,
-            SUM(CASE WHEN seller_id = ? OR buyer_id = ? THEN 1 ELSE 0 END) as successful_trades
+            COUNT(*) as successful_trades
         FROM completed_trades
-        WHERE seller_id = ? OR buyer_id = ?
-    `).bind(userId, userId, userId, userId).first();
+        WHERE seller_id IN (?, ?) OR buyer_id IN (?, ?)
+    `).bind(...forms, ...forms).first();
 
     const reviews = await env.DBA.prepare(`
         SELECT
             AVG(rating) as avg_rating,
             COUNT(*) as review_count
         FROM trade_reviews
-        WHERE reviewed_user_id = ?
-    `).bind(userId).first();
+        WHERE reviewed_user_id IN (?, ?)
+    `).bind(...forms).first();
 
     await env.DBA.prepare(`
         INSERT INTO user_trade_stats (user_id, total_trades, successful_trades, average_rating, total_reviews, last_trade_at)
@@ -111,7 +140,8 @@ export async function updateUserStats(env, userId) {
 }
 
 // Get user with stats
-export async function getUserWithStats(env, userId) {
+export async function getUserWithStats(env, rawUserId) {
+    const userId = normalizeUserId(rawUserId);
     const user = await env.DBA.prepare(`
         SELECT
             u.user_id,
@@ -131,6 +161,9 @@ export async function getUserWithStats(env, userId) {
 
     if (user) {
         user.roles = typeof user.roles === 'string' ? JSON.parse(user.roles) : user.roles;
+        // Hand ids back in canonical string form so they don't re-enter the
+        // float-artifact cycle when clients echo them into later requests.
+        user.user_id = normalizeUserId(user.user_id);
     }
 
     return user;

--- a/functions/api/trades/completed/[[path]].js
+++ b/functions/api/trades/completed/[[path]].js
@@ -5,7 +5,9 @@ import {
     successResponse,
     getUserWithStats,
     parsePagination,
-    safeJsonParse
+    safeJsonParse,
+    userIdForms,
+    isSameUser
 } from '../_utils/helpers.js';
 
 // Handle GET requests
@@ -20,19 +22,21 @@ async function handleGet(request, env, path, user) {
     if (!path || path === '') {
         const { limit, offset } = parsePagination(url);
 
+        // Match both the canonical and legacy ".0" id forms (see helpers).
+        const me = userIdForms(user.user_id);
         const { results } = await env.DBA.prepare(`
             SELECT
                 ct.*,
                 (SELECT COUNT(*) FROM trade_reviews r
-                 WHERE r.trade_id = ct.id AND r.reviewer_id = ?) AS reviewed_by_me
+                 WHERE r.trade_id = ct.id AND r.reviewer_id IN (?, ?)) AS reviewed_by_me
             FROM completed_trades ct
-            WHERE ct.seller_id = ? OR ct.buyer_id = ?
+            WHERE ct.seller_id IN (?, ?) OR ct.buyer_id IN (?, ?)
             ORDER BY ct.completed_at DESC
             LIMIT ? OFFSET ?
-        `).bind(user.user_id, user.user_id, user.user_id, limit, offset).all();
+        `).bind(...me, ...me, ...me, limit, offset).all();
 
         const trades = await Promise.all((results || []).map(async (trade) => {
-            const isSeller = trade.seller_id === user.user_id;
+            const isSeller = isSameUser(trade.seller_id, user.user_id);
             const otherUserId = isSeller ? trade.buyer_id : trade.seller_id;
             const otherUser = await getUserWithStats(env, otherUserId);
 
@@ -71,17 +75,17 @@ async function handleGet(request, env, path, user) {
         }
 
         // Only participants can view
-        if (trade.seller_id !== user.user_id && trade.buyer_id !== user.user_id) {
+        if (!isSameUser(trade.seller_id, user.user_id) && !isSameUser(trade.buyer_id, user.user_id)) {
             return errorResponse('Unauthorized to view this trade', 403);
         }
 
-        const isSeller = trade.seller_id === user.user_id;
+        const isSeller = isSameUser(trade.seller_id, user.user_id);
         const otherUserId = isSeller ? trade.buyer_id : trade.seller_id;
         const otherUser = await getUserWithStats(env, otherUserId);
 
         const existingReview = await env.DBA.prepare(
-            'SELECT id FROM trade_reviews WHERE trade_id = ? AND reviewer_id = ?'
-        ).bind(tradeId, user.user_id).first();
+            'SELECT id FROM trade_reviews WHERE trade_id = ? AND reviewer_id IN (?, ?)'
+        ).bind(tradeId, ...userIdForms(user.user_id)).first();
 
         return successResponse({
             trade: {

--- a/functions/api/trades/listings/[[path]].js
+++ b/functions/api/trades/listings/[[path]].js
@@ -7,7 +7,10 @@ import {
     parsePagination,
     parseSort,
     getUserWithStats,
-    safeJsonParse
+    safeJsonParse,
+    normalizeUserId,
+    userIdForms,
+    isSameUser
 } from '../_utils/helpers.js';
 
 // Roles that unlock card themes (mirrors TradingHub.THEME_ROLES on the client).
@@ -40,6 +43,39 @@ async function handleGet(request, env, path) {
         const status = params.get('status') || 'active';
         const search = params.get('search');
 
+        // Shared WHERE clause for both the page query and the total count, so
+        // the client can render numbered pagination.
+        let where = ' WHERE 1=1';
+        const whereBindings = [];
+
+        // 'all' (or empty) means no status filter — otherwise the query would
+        // literally match `status = 'all'` and return nothing.
+        if (status && status !== 'all') {
+            where += ' AND tl.status = ?';
+            whereBindings.push(status);
+        }
+
+        if (category && category !== 'all') {
+            where += ' AND tl.category = ?';
+            whereBindings.push(category);
+        }
+
+        if (userId) {
+            // Match both the canonical id and the legacy ".0" float-artifact
+            // form so pre-cleanup rows still show up (see helpers.userIdForms).
+            where += ' AND tl.user_id IN (?, ?)';
+            whereBindings.push(...userIdForms(userId));
+        }
+
+        if (search) {
+            // Titles are auto-generated ("Trading X + 26 more"), so most item
+            // names never appear in them — search the item JSON too, where the
+            // stored item_name values live.
+            where += ' AND (tl.title LIKE ? OR tl.description LIKE ? OR tl.offering_items LIKE ? OR tl.seeking_items LIKE ?)';
+            const term = `%${search}%`;
+            whereBindings.push(term, term, term, term);
+        }
+
         let query = `
             SELECT
                 tl.*,
@@ -52,36 +88,15 @@ async function handleGet(request, env, path) {
             FROM trade_listings tl
             LEFT JOIN users u ON u.user_id = tl.user_id
             LEFT JOIN user_trade_stats uts ON uts.user_id = tl.user_id
-            WHERE 1=1
         `;
-        const bindings = [];
+        query += where + ` ORDER BY tl.${sortBy} ${sortOrder} LIMIT ? OFFSET ?`;
+        const bindings = [...whereBindings, limit, offset];
 
-        // 'all' (or empty) means no status filter — otherwise the query would
-        // literally match `status = 'all'` and return nothing.
-        if (status && status !== 'all') {
-            query += ' AND tl.status = ?';
-            bindings.push(status);
-        }
-
-        if (category && category !== 'all') {
-            query += ' AND tl.category = ?';
-            bindings.push(category);
-        }
-
-        if (userId) {
-            query += ' AND tl.user_id = ?';
-            bindings.push(userId);
-        }
-
-        if (search) {
-            query += ' AND (tl.title LIKE ? OR tl.description LIKE ?)';
-            bindings.push(`%${search}%`, `%${search}%`);
-        }
-
-        query += ` ORDER BY tl.${sortBy} ${sortOrder} LIMIT ? OFFSET ?`;
-        bindings.push(limit, offset);
-
-        const { results } = await env.DBA.prepare(query).bind(...bindings).all();
+        const [{ results }, countRow] = await Promise.all([
+            env.DBA.prepare(query).bind(...bindings).all(),
+            env.DBA.prepare(`SELECT COUNT(*) AS total FROM trade_listings tl${where}`)
+                .bind(...whereBindings).first()
+        ]);
 
         const listings = (results || []).map((row) => {
             const {
@@ -93,10 +108,11 @@ async function handleGet(request, env, path) {
 
             return {
                 ...listing,
+                user_id: normalizeUserId(listing.user_id),
                 offering_items: safeJsonParse(offering_items),
                 seeking_items: seeking_items ? safeJsonParse(seeking_items, null) : null,
                 user: {
-                    user_id: u_user_id,
+                    user_id: normalizeUserId(u_user_id),
                     username: u_username,
                     display_name: u_display_name,
                     avatar_url: u_avatar_url,
@@ -106,7 +122,7 @@ async function handleGet(request, env, path) {
             };
         });
 
-        return successResponse({ listings, limit, offset });
+        return successResponse({ listings, limit, offset, total: countRow?.total ?? listings.length });
     }
 
     // GET /api/trades/listings/:id - Get specific listing
@@ -135,6 +151,7 @@ async function handleGet(request, env, path) {
 
         return successResponse({
             ...listing,
+            user_id: normalizeUserId(listing.user_id),
             offering_items: safeJsonParse(listing.offering_items),
             seeking_items: listing.seeking_items ? safeJsonParse(listing.seeking_items, null) : null,
             views: listing.views + 1,
@@ -309,7 +326,7 @@ async function handlePut(request, env, path, user) {
         return errorResponse('Listing not found', 404);
     }
 
-    if (listing.user_id !== user.user_id) {
+    if (!isSameUser(listing.user_id, user.user_id)) {
         return errorResponse('You can only edit your own listings', 403);
     }
 
@@ -387,7 +404,7 @@ async function handleDelete(request, env, path, user) {
         return errorResponse('Listing not found', 404);
     }
 
-    if (listing.user_id !== user.user_id) {
+    if (!isSameUser(listing.user_id, user.user_id)) {
         return errorResponse('You can only delete your own listings', 403);
     }
 

--- a/functions/api/trades/messages/[[path]].js
+++ b/functions/api/trades/messages/[[path]].js
@@ -5,7 +5,10 @@ import {
     successResponse,
     validateFields,
     createNotification,
-    getUserWithStats
+    getUserWithStats,
+    normalizeUserId,
+    userIdForms,
+    isSameUser
 } from '../_utils/helpers.js';
 
 // Handle GET requests
@@ -22,8 +25,11 @@ async function handleGet(request, env, path, user) {
         const offerId = url.searchParams.get('offer_id');
         const withUserId = url.searchParams.get('with_user_id');
 
-        let query = 'SELECT * FROM trade_messages WHERE (from_user_id = ? OR to_user_id = ?)';
-        const bindings = [user.user_id, user.user_id];
+        // Legacy rows can store ids as "123.0" (see helpers.userIdForms), so
+        // every user-id match checks both encodings.
+        const me = userIdForms(user.user_id);
+        let query = 'SELECT * FROM trade_messages WHERE (from_user_id IN (?, ?) OR to_user_id IN (?, ?))';
+        const bindings = [...me, ...me];
 
         if (listingId) {
             query += ' AND listing_id = ?';
@@ -36,8 +42,9 @@ async function handleGet(request, env, path, user) {
         }
 
         if (withUserId) {
-            query += ' AND (from_user_id = ? OR to_user_id = ?)';
-            bindings.push(withUserId, withUserId);
+            const them = userIdForms(withUserId);
+            query += ' AND (from_user_id IN (?, ?) OR to_user_id IN (?, ?))';
+            bindings.push(...them, ...them);
         }
 
         query += ' ORDER BY created_at ASC';
@@ -51,25 +58,27 @@ async function handleGet(request, env, path, user) {
 
             return {
                 ...msg,
-                from_user: {
+                from_user_id: normalizeUserId(msg.from_user_id),
+                to_user_id: normalizeUserId(msg.to_user_id),
+                from_user: fromUser ? {
                     user_id: fromUser.user_id,
                     username: fromUser.username,
                     display_name: fromUser.display_name,
                     avatar_url: fromUser.avatar_url
-                },
-                to_user: {
+                } : null,
+                to_user: toUser ? {
                     user_id: toUser.user_id,
                     username: toUser.username,
                     display_name: toUser.display_name,
                     avatar_url: toUser.avatar_url
-                }
+                } : null
             };
         }));
 
         // Mark messages as read that were sent to this user
         if (messages.length > 0) {
             const messageIds = messages
-                .filter(m => m.to_user_id === user.user_id && !m.read)
+                .filter(m => isSameUser(m.to_user_id, user.user_id) && !m.read)
                 .map(m => m.id);
 
             if (messageIds.length > 0) {
@@ -86,30 +95,34 @@ async function handleGet(request, env, path, user) {
     // GET /api/trades/messages/unread - Get unread message count
     if (path === 'unread') {
         const result = await env.DBA.prepare(
-            'SELECT COUNT(*) as count FROM trade_messages WHERE to_user_id = ? AND read = 0'
-        ).bind(user.user_id).first();
+            'SELECT COUNT(*) as count FROM trade_messages WHERE to_user_id IN (?, ?) AND read = 0'
+        ).bind(...userIdForms(user.user_id)).first();
 
         return successResponse({ unread_count: result.count });
     }
 
     // GET /api/trades/messages/conversations - Get list of conversations
     if (path === 'conversations') {
-        // Get unique conversations with last message
+        // Get unique conversations with last message. The other party's id is
+        // normalized in SQL (user ids are digit strings, so the only '.0' a
+        // legacy value can contain is the float-artifact suffix) — otherwise
+        // "123" and "123.0" would split one conversation into two.
+        const me = userIdForms(user.user_id);
         const { results } = await env.DBA.prepare(`
             SELECT
-                CASE
-                    WHEN from_user_id = ? THEN to_user_id
+                REPLACE(CASE
+                    WHEN from_user_id IN (?, ?) THEN to_user_id
                     ELSE from_user_id
-                END as other_user_id,
+                END, '.0', '') as other_user_id,
                 listing_id,
-                offer_id,
+                MAX(offer_id) as offer_id,
                 MAX(created_at) as last_message_at,
-                COUNT(CASE WHEN to_user_id = ? AND read = 0 THEN 1 END) as unread_count
+                COUNT(CASE WHEN to_user_id IN (?, ?) AND read = 0 THEN 1 END) as unread_count
             FROM trade_messages
-            WHERE from_user_id = ? OR to_user_id = ?
-            GROUP BY other_user_id, listing_id, offer_id
+            WHERE from_user_id IN (?, ?) OR to_user_id IN (?, ?)
+            GROUP BY other_user_id, listing_id
             ORDER BY last_message_at DESC
-        `).bind(user.user_id, user.user_id, user.user_id, user.user_id).all();
+        `).bind(...me, ...me, ...me, ...me).all();
 
         // Get details for each conversation
         const conversations = await Promise.all(results.map(async (conv) => {
@@ -160,10 +173,11 @@ async function handlePost(request, env, path, user) {
             return errorResponse(error);
         }
 
-        const { to_user_id, message, listing_id, offer_id } = data;
+        const { message, listing_id, offer_id } = data;
+        const to_user_id = normalizeUserId(data.to_user_id);
 
         // Can't send message to self
-        if (to_user_id === user.user_id) {
+        if (isSameUser(to_user_id, user.user_id)) {
             return errorResponse('Cannot send message to yourself', 400);
         }
 
@@ -190,11 +204,12 @@ async function handlePost(request, env, path, user) {
             // Valid if: the sender owns the listing (replying to an interested party),
             // the sender is messaging the owner (asking about the listing before
             // offering), or either side already has an offer on it.
-            const isListingOwner = listing.user_id === user.user_id;
-            const messagingOwner = to_user_id === listing.user_id;
+            const isListingOwner = isSameUser(listing.user_id, user.user_id);
+            const messagingOwner = isSameUser(to_user_id, listing.user_id);
+            const me = userIdForms(user.user_id);
             const hasOffer = await env.DBA.prepare(
-                'SELECT id FROM trade_offers WHERE listing_id = ? AND (from_user_id = ? OR to_user_id = ?)'
-            ).bind(listing_id, user.user_id, user.user_id).first();
+                'SELECT id FROM trade_offers WHERE listing_id = ? AND (from_user_id IN (?, ?) OR to_user_id IN (?, ?))'
+            ).bind(listing_id, ...me, ...me).first();
 
             if (!isListingOwner && !messagingOwner && !hasOffer) {
                 return errorResponse('You are not involved in this listing', 403);
@@ -247,7 +262,7 @@ async function handlePost(request, env, path, user) {
         }
 
         // Must be the recipient
-        if (message.to_user_id !== user.user_id) {
+        if (!isSameUser(message.to_user_id, user.user_id)) {
             return errorResponse('You can only mark your own messages as read', 403);
         }
 

--- a/functions/api/trades/notifications/[[path]].js
+++ b/functions/api/trades/notifications/[[path]].js
@@ -2,7 +2,9 @@ import {
     authenticateUser,
     isAuthorized,
     errorResponse,
-    successResponse
+    successResponse,
+    userIdForms,
+    isSameUser
 } from '../_utils/helpers.js';
 
 // Handle GET requests
@@ -19,8 +21,9 @@ async function handleGet(request, env, path, user) {
         const limit = Math.min(parseInt(url.searchParams.get('limit') || '50'), 100);
         const offset = parseInt(url.searchParams.get('offset') || '0');
 
-        let query = 'SELECT * FROM trade_notifications WHERE user_id = ?';
-        const bindings = [user.user_id];
+        // Match both the canonical and legacy ".0" id forms (see helpers).
+        let query = 'SELECT * FROM trade_notifications WHERE user_id IN (?, ?)';
+        const bindings = [...userIdForms(user.user_id)];
 
         if (unreadOnly) {
             query += ' AND read = 0';
@@ -37,8 +40,8 @@ async function handleGet(request, env, path, user) {
     // GET /api/trades/notifications/unread-count - Get unread count
     if (path === 'unread-count') {
         const result = await env.DBA.prepare(
-            'SELECT COUNT(*) as count FROM trade_notifications WHERE user_id = ? AND read = 0'
-        ).bind(user.user_id).first();
+            'SELECT COUNT(*) as count FROM trade_notifications WHERE user_id IN (?, ?) AND read = 0'
+        ).bind(...userIdForms(user.user_id)).first();
 
         return successResponse({ unread_count: result.count });
     }
@@ -55,7 +58,7 @@ async function handleGet(request, env, path, user) {
         }
 
         // Can only view own notifications
-        if (notification.user_id !== user.user_id) {
+        if (!isSameUser(notification.user_id, user.user_id)) {
             return errorResponse('Unauthorized to view this notification', 403);
         }
 
@@ -86,7 +89,7 @@ async function handlePost(request, env, path, user) {
         }
 
         // Can only mark own notifications as read
-        if (notification.user_id !== user.user_id) {
+        if (!isSameUser(notification.user_id, user.user_id)) {
             return errorResponse('Unauthorized', 403);
         }
 
@@ -100,8 +103,8 @@ async function handlePost(request, env, path, user) {
     // POST /api/trades/notifications/read-all - Mark all as read
     if (path === 'read-all') {
         await env.DBA.prepare(
-            'UPDATE trade_notifications SET read = 1 WHERE user_id = ? AND read = 0'
-        ).bind(user.user_id).run();
+            'UPDATE trade_notifications SET read = 1 WHERE user_id IN (?, ?) AND read = 0'
+        ).bind(...userIdForms(user.user_id)).run();
 
         return successResponse({ message: 'All notifications marked as read' });
     }
@@ -130,7 +133,7 @@ async function handleDelete(request, env, path, user) {
     }
 
     // Can only delete own notifications
-    if (notification.user_id !== user.user_id) {
+    if (!isSameUser(notification.user_id, user.user_id)) {
         return errorResponse('Unauthorized', 403);
     }
 

--- a/functions/api/trades/offers/[[path]].js
+++ b/functions/api/trades/offers/[[path]].js
@@ -7,7 +7,10 @@ import {
     createNotification,
     updateUserStats,
     getUserWithStats,
-    safeJsonParse
+    safeJsonParse,
+    normalizeUserId,
+    userIdForms,
+    isSameUser
 } from '../_utils/helpers.js';
 
 // Handle GET requests
@@ -26,15 +29,17 @@ async function handleGet(request, env, path, user) {
         let query = 'SELECT o.*, l.title as listing_title FROM trade_offers o JOIN trade_listings l ON o.listing_id = l.id WHERE 1=1';
         const bindings = [];
 
+        // Match both the canonical and legacy ".0" id forms (see helpers).
+        const me = userIdForms(user.user_id);
         if (type === 'sent') {
-            query += ' AND o.from_user_id = ?';
-            bindings.push(user.user_id);
+            query += ' AND o.from_user_id IN (?, ?)';
+            bindings.push(...me);
         } else if (type === 'received') {
-            query += ' AND o.to_user_id = ?';
-            bindings.push(user.user_id);
+            query += ' AND o.to_user_id IN (?, ?)';
+            bindings.push(...me);
         } else {
-            query += ' AND (o.from_user_id = ? OR o.to_user_id = ?)';
-            bindings.push(user.user_id, user.user_id);
+            query += ' AND (o.from_user_id IN (?, ?) OR o.to_user_id IN (?, ?))';
+            bindings.push(...me, ...me);
         }
 
         if (status) {
@@ -53,21 +58,23 @@ async function handleGet(request, env, path, user) {
 
             return {
                 ...offer,
+                from_user_id: normalizeUserId(offer.from_user_id),
+                to_user_id: normalizeUserId(offer.to_user_id),
                 offered_items: safeJsonParse(offer.offered_items),
-                from_user: {
+                from_user: fromUser ? {
                     user_id: fromUser.user_id,
                     username: fromUser.username,
                     display_name: fromUser.display_name,
                     avatar_url: fromUser.avatar_url,
                     average_rating: fromUser.average_rating || 0
-                },
-                to_user: {
+                } : null,
+                to_user: toUser ? {
                     user_id: toUser.user_id,
                     username: toUser.username,
                     display_name: toUser.display_name,
                     avatar_url: toUser.avatar_url,
                     average_rating: toUser.average_rating || 0
-                }
+                } : null
             };
         }));
 
@@ -86,7 +93,7 @@ async function handleGet(request, env, path, user) {
         }
 
         // Check authorization - must be sender or receiver
-        if (offer.from_user_id !== user.user_id && offer.to_user_id !== user.user_id) {
+        if (!isSameUser(offer.from_user_id, user.user_id) && !isSameUser(offer.to_user_id, user.user_id)) {
             return errorResponse('Unauthorized to view this offer', 403);
         }
 
@@ -95,6 +102,8 @@ async function handleGet(request, env, path, user) {
 
         return successResponse({
             ...offer,
+            from_user_id: normalizeUserId(offer.from_user_id),
+            to_user_id: normalizeUserId(offer.to_user_id),
             offered_items: safeJsonParse(offer.offered_items),
             listing_items: safeJsonParse(offer.listing_items),
             from_user: {
@@ -146,7 +155,7 @@ async function handlePost(request, env, path, user) {
         }
 
         // Can't make offer on own listing
-        if (listing.user_id === user.user_id) {
+        if (isSameUser(listing.user_id, user.user_id)) {
             return errorResponse('Cannot make offer on your own listing', 400);
         }
 
@@ -164,7 +173,7 @@ async function handlePost(request, env, path, user) {
         ).bind(
             listing_id,
             user.user_id,
-            listing.user_id,
+            normalizeUserId(listing.user_id),
             JSON.stringify(offered_items),
             message || null,
             now,
@@ -202,7 +211,7 @@ async function handlePost(request, env, path, user) {
         }
 
         // Must be the listing owner
-        if (offer.to_user_id !== user.user_id) {
+        if (!isSameUser(offer.to_user_id, user.user_id)) {
             return errorResponse('Only the listing owner can accept offers', 403);
         }
 
@@ -237,8 +246,8 @@ async function handlePost(request, env, path, user) {
         ).bind(
             offer.listing_id,
             offerId,
-            offer.to_user_id,
-            offer.from_user_id,
+            normalizeUserId(offer.to_user_id),
+            normalizeUserId(offer.from_user_id),
             offer.listing_items,
             offer.offered_items,
             now
@@ -280,7 +289,7 @@ async function handlePost(request, env, path, user) {
         }
 
         // Must be the listing owner
-        if (offer.to_user_id !== user.user_id) {
+        if (!isSameUser(offer.to_user_id, user.user_id)) {
             return errorResponse('Only the listing owner can reject offers', 403);
         }
 
@@ -313,7 +322,7 @@ async function handlePost(request, env, path, user) {
         }
 
         // Must be the offer sender
-        if (offer.from_user_id !== user.user_id) {
+        if (!isSameUser(offer.from_user_id, user.user_id)) {
             return errorResponse('You can only cancel your own offers', 403);
         }
 

--- a/functions/api/trades/reviews/[[path]].js
+++ b/functions/api/trades/reviews/[[path]].js
@@ -6,7 +6,10 @@ import {
     validateFields,
     createNotification,
     updateUserStats,
-    getUserWithStats
+    getUserWithStats,
+    normalizeUserId,
+    userIdForms,
+    isSameUser
 } from '../_utils/helpers.js';
 
 // Handle GET requests
@@ -29,14 +32,14 @@ async function handleGet(request, env, path) {
                 u.avatar_url as reviewer_avatar
             FROM trade_reviews r
             JOIN users u ON r.reviewer_id = u.user_id
-            WHERE r.reviewed_user_id = ?
+            WHERE r.reviewed_user_id IN (?, ?)
             ORDER BY r.created_at DESC
-        `).bind(userId).all();
+        `).bind(...userIdForms(userId)).all();
 
         // Get user stats
         const stats = await env.DBA.prepare(
-            'SELECT * FROM user_trade_stats WHERE user_id = ?'
-        ).bind(userId).first();
+            'SELECT * FROM user_trade_stats WHERE user_id IN (?, ?)'
+        ).bind(...userIdForms(userId)).first();
 
         return successResponse({
             reviews,
@@ -109,17 +112,19 @@ async function handlePost(request, env, path, user) {
         }
 
         // Verify user was part of the trade
-        if (trade.seller_id !== user.user_id && trade.buyer_id !== user.user_id) {
+        if (!isSameUser(trade.seller_id, user.user_id) && !isSameUser(trade.buyer_id, user.user_id)) {
             return errorResponse('You were not part of this trade', 403);
         }
 
         // Determine who is being reviewed
-        const reviewedUserId = trade.seller_id === user.user_id ? trade.buyer_id : trade.seller_id;
+        const reviewedUserId = normalizeUserId(
+            isSameUser(trade.seller_id, user.user_id) ? trade.buyer_id : trade.seller_id
+        );
 
         // Check if user already reviewed this trade
         const existingReview = await env.DBA.prepare(
-            'SELECT id FROM trade_reviews WHERE trade_id = ? AND reviewer_id = ?'
-        ).bind(trade_id, user.user_id).first();
+            'SELECT id FROM trade_reviews WHERE trade_id = ? AND reviewer_id IN (?, ?)'
+        ).bind(trade_id, ...userIdForms(user.user_id)).first();
 
         if (existingReview) {
             return errorResponse('You have already reviewed this trade', 400);
@@ -187,7 +192,7 @@ async function handlePut(request, env, path, user) {
     }
 
     // Can only edit own reviews
-    if (review.reviewer_id !== user.user_id) {
+    if (!isSameUser(review.reviewer_id, user.user_id)) {
         return errorResponse('You can only edit your own reviews', 403);
     }
 
@@ -250,7 +255,7 @@ async function handleDelete(request, env, path, user) {
     const roles = typeof user.roles === 'string' ? JSON.parse(user.roles) : user.roles;
     const isAdminOrMod = roles.includes('admin') || roles.includes('moderator');
 
-    if (review.reviewer_id !== user.user_id && !isAdminOrMod) {
+    if (!isSameUser(review.reviewer_id, user.user_id) && !isAdminOrMod) {
         return errorResponse('You can only delete your own reviews', 403);
     }
 

--- a/js/trading.js
+++ b/js/trading.js
@@ -4,9 +4,9 @@ class TradingHub {
         this.trades = [];
         this.myTrades = [];
         this.allItems = [];
-        // Browse-feed pagination (the API caps one request at 100 rows).
-        this.browseOffset = 0;
-        this.browseHasMore = false;
+        // Browse-feed pagination: numbered pages over the server's total count.
+        this.browsePage = 1;
+        this.browseTotal = 0;
         this.wishlist = [];          // item names on the signed-in user's wishlist
         this._wishlistSet = new Set(); // lowercased, for fast lookup while sorting
         this.filters = {
@@ -57,6 +57,11 @@ class TradingHub {
         this.notifications = [];
         this.unreadNotifications = 0;
         this.notifPollTimer = null;
+        this.autoRefreshTimer = null;
+        this.msgPollTimer = null;
+        // Change fingerprints so background polls only re-render on new data.
+        this._threadFingerprint = null;
+        this._convFingerprint = null;
         this.reviewState = { tradeId: null, rating: 0 };
         // Last seen unread counts, for firing an OS notification only on an
         // increase. null = not polled yet (so we never notify on first load).
@@ -95,6 +100,54 @@ class TradingHub {
             this.refreshBadges();
             this.startNotificationPolling();
         }
+
+        // Keep the visible tab's data fresh without manual reloads.
+        this.startAutoRefresh();
+    }
+
+    // ==================== AUTO-REFRESH ====================
+
+    // How often the visible feed re-fetches (browse / my-trades).
+    static FEED_REFRESH_MS = 30000;
+    // How often conversations + the open thread poll while the messages modal is open.
+    static MESSAGES_POLL_MS = 10000;
+
+    startAutoRefresh() {
+        if (this.autoRefreshTimer) clearInterval(this.autoRefreshTimer);
+        this.autoRefreshTimer = setInterval(() => this.refreshActivePanel(), TradingHub.FEED_REFRESH_MS);
+
+        // Catch up immediately when the user returns to the tab.
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState !== 'visible') return;
+            this.refreshActivePanel();
+            if (this.currentUser) this.refreshBadges();
+        });
+    }
+
+    refreshActivePanel() {
+        if (document.visibilityState !== 'visible') return;
+        // Only re-render when the data actually changed, so a background poll
+        // never yanks the feed out from under the user mid-scroll/click.
+        if (this.activeTab === 'browse') {
+            const before = this._browseFingerprint();
+            this.loadTrades(this.browsePage).then(() => {
+                if (this._browseFingerprint() !== before) this.renderTrades();
+            });
+        } else if (this.activeTab === 'my-trades' && this.currentUser) {
+            const before = this._myTradesFingerprint();
+            this.loadMyTrades().then(() => {
+                if (this._myTradesFingerprint() !== before) this.renderMyTrades();
+            });
+        }
+    }
+
+    _browseFingerprint() {
+        return this.browseTotal + ':' + this.trades.map(t => `${t.id}.${t.status}.${t.updated_at}`).join(',');
+    }
+
+    _myTradesFingerprint() {
+        const ids = (arr, key = 'status') => arr.map(x => `${x.id}.${x[key]}`).join(',');
+        return `${ids(this.myTrades)}|${ids(this.receivedOffers)}|${ids(this.sentOffers)}|${ids(this.completedTrades, 'reviewed_by_me')}`;
     }
 
     // Authorization header for authenticated requests (empty if logged out).
@@ -169,17 +222,16 @@ class TradingHub {
         };
     }
 
-    // Load a page of the browse feed. reset=true (default) starts over — used by
-    // init, tab switches and filter/search changes; reset=false appends the next
-    // page ("Load More"). The API caps a single request at 100 rows, so paging
-    // is the only way to see everything.
-    async loadTrades(reset = true) {
-        if (reset) this.browseOffset = 0;
+    // Load one page of the browse feed (1-based page number). The server
+    // returns the total row count for the current filters, which drives the
+    // numbered pagination bar.
+    async loadTrades(page = 1) {
+        this.browsePage = Math.max(1, page);
         try {
             const params = new URLSearchParams({
                 status: this.filters.status,
                 limit: String(TradingHub.BROWSE_PAGE_SIZE),
-                offset: String(this.browseOffset),
+                offset: String((this.browsePage - 1) * TradingHub.BROWSE_PAGE_SIZE),
                 ...(this.filters.search && { search: this.filters.search })
             });
 
@@ -187,24 +239,24 @@ class TradingHub {
             if (!response.ok) throw new Error('Failed to load trades');
 
             const data = await response.json();
-            const batch = (data.listings || []).map(l => this.mapListing(l));
-            this.trades = reset ? batch : [...this.trades, ...batch];
-            this.browseOffset += batch.length;
-            // A full page means there are probably more rows behind it.
-            this.browseHasMore = batch.length === TradingHub.BROWSE_PAGE_SIZE;
+            this.trades = (data.listings || []).map(l => this.mapListing(l));
+            this.browseTotal = Number.isFinite(data.total) ? data.total : this.trades.length;
         } catch (error) {
             console.error('Error loading trades:', error);
             this.showToast('Failed to load trades', 'error');
         }
     }
 
-    async loadMoreTrades() {
-        const btn = document.getElementById('loadMoreBtn');
-        if (btn) { btn.disabled = true; btn.textContent = 'Loading…'; }
-        await this.loadTrades(false);
-        if (btn) { btn.disabled = false; btn.textContent = 'Load More'; }
+    browsePageCount() {
+        return Math.max(1, Math.ceil(this.browseTotal / TradingHub.BROWSE_PAGE_SIZE));
+    }
+
+    async goToPage(page) {
+        const target = Math.min(Math.max(1, page), this.browsePageCount());
+        await this.loadTrades(target);
         this.renderTrades();
-        this.updateStats();
+        // Put the top of the new page in view.
+        document.querySelector('.trading-tabs, #tradesFeed')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
 
     async loadMyTrades() {
@@ -293,7 +345,11 @@ class TradingHub {
     }
 
     updateStats() {
-        const activeTrades = this.trades.filter(t => t.status === 'active').length;
+        // With paged results the server total is the real count for the current
+        // status filter; fall back to counting the page for other filters.
+        const activeTrades = this.filters.status === 'active'
+            ? this.browseTotal
+            : this.trades.filter(t => t.status === 'active').length;
         const completed = this.trades.filter(t => t.status === 'completed').length;
         const uniqueTraders = new Set(this.trades.map(t => t.user_id)).size;
 
@@ -336,8 +392,12 @@ class TradingHub {
             });
         }
 
-        // Browse feed pagination
-        document.getElementById('loadMoreBtn')?.addEventListener('click', () => this.loadMoreTrades());
+        // Browse feed pagination (numbered page buttons, rendered dynamically)
+        document.getElementById('paginationContainer')?.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-page]');
+            if (!btn || btn.disabled) return;
+            this.goToPage(parseInt(btn.dataset.page, 10));
+        });
 
         // Filters
         document.getElementById('filterStatus')?.addEventListener('change', (e) => {
@@ -486,7 +546,7 @@ class TradingHub {
         if (tab === 'browse') {
             document.getElementById('panelBrowse')?.classList.add('active');
             // Refetch so the feed isn't frozen at whatever loaded on page-open.
-            this.loadTrades().then(() => this.renderTrades());
+            this.loadTrades(this.browsePage).then(() => this.renderTrades());
         } else if (tab === 'my-trades') {
             document.getElementById('panelMyTrades')?.classList.add('active');
             if (!this.currentUser) {
@@ -914,10 +974,17 @@ class TradingHub {
             filtered = filtered.filter(t => t.status === this.filters.status);
         }
         if (this.filters.search) {
+            // Mirror the server's search: title, description, or any item name
+            // on either side of the trade.
             const q = this.filters.search.toLowerCase();
+            const itemMatch = (items) => (items || []).some(i =>
+                (i.item_name || i.game_name || '').toLowerCase().includes(q)
+            );
             filtered = filtered.filter(t =>
                 t.title?.toLowerCase().includes(q) ||
-                t.description?.toLowerCase().includes(q)
+                t.description?.toLowerCase().includes(q) ||
+                itemMatch(t.offering_items) ||
+                itemMatch(t.seeking_items)
             );
         }
 
@@ -939,11 +1006,9 @@ class TradingHub {
             filtered.sort((a, b) => b.created_at - a.created_at);
         }
 
-        // "Load More" is visible whenever the server may have another page —
-        // even alongside the empty state (client-side filters can hide a whole
-        // page while more rows exist behind it).
-        const loadMore = document.getElementById('loadMoreContainer');
-        if (loadMore) loadMore.style.display = this.browseHasMore ? '' : 'none';
+        // The pagination bar stays visible even alongside the empty state —
+        // other pages can still hold results.
+        this.renderPagination();
 
         if (filtered.length === 0) {
             feed.innerHTML = `
@@ -964,6 +1029,37 @@ class TradingHub {
         });
 
         this.updateStats();
+    }
+
+    // Numbered page buttons (‹ 1 … 4 [5] 6 … 12 ›): first/last always shown,
+    // ±1 around the current page, gaps collapsed to an ellipsis.
+    renderPagination() {
+        const container = document.getElementById('paginationContainer');
+        if (!container) return;
+        const pages = this.browsePageCount();
+        if (pages <= 1) {
+            container.innerHTML = '';
+            container.style.display = 'none';
+            return;
+        }
+        container.style.display = '';
+
+        const current = Math.min(this.browsePage, pages);
+        const wanted = new Set([1, pages, current - 1, current, current + 1]);
+        const parts = [];
+        let prev = 0;
+        for (let p = 1; p <= pages; p++) {
+            if (!wanted.has(p)) continue;
+            if (prev && p - prev > 1) parts.push('<span class="page-ellipsis">…</span>');
+            parts.push(`<button type="button" class="page-btn${p === current ? ' active' : ''}" data-page="${p}"${p === current ? ' aria-current="page"' : ''}>${p}</button>`);
+            prev = p;
+        }
+
+        container.innerHTML = `
+            <button type="button" class="page-btn page-nav" data-page="${current - 1}"${current <= 1 ? ' disabled' : ''} aria-label="Previous page">‹</button>
+            ${parts.join('')}
+            <button type="button" class="page-btn page-nav" data-page="${current + 1}"${current >= pages ? ' disabled' : ''} aria-label="Next page">›</button>
+        `;
     }
 
     createTradeCard(trade) {
@@ -1547,12 +1643,10 @@ class TradingHub {
     }
 
     openCustomItemForOffer() {
-        // Re-use the existing custom item modal but route its result into the offer state.
-        // The wizard's custom modal flow uses `this.currentCustomItemsKey` to know where to push.
-        // We set a sentinel value the existing handler honors via addOfferCustomItem().
-        this.currentCustomItemsKey = '__offer__';
-        const modal = document.getElementById('customItemModal');
-        if (modal) modal.classList.add('active');
+        // Re-use the shared custom item modal; the '__offer__' sentinel routes
+        // the result into the offer state (see addCustomItem). openCustomModal
+        // also resets the type toggle and clears stale field values.
+        this.openCustomModal('__offer__');
     }
 
     async submitOffer() {
@@ -1835,21 +1929,49 @@ class TradingHub {
     openMessagesModal() {
         document.getElementById('messagesModal')?.classList.add('active');
         this.loadConversations();
+        this.startMessagesPolling();
     }
 
     closeMessagesModal() {
         document.getElementById('messagesModal')?.classList.remove('active');
+        this.stopMessagesPolling();
+    }
+
+    // While the messages modal is open, poll for new messages so replies show
+    // up without reopening the modal.
+    startMessagesPolling() {
+        this.stopMessagesPolling();
+        this.msgPollTimer = setInterval(() => {
+            if (document.visibilityState !== 'visible') return;
+            this.loadConversations();
+            if (this.activeThread) this.loadThread({ silent: true });
+        }, TradingHub.MESSAGES_POLL_MS);
+    }
+
+    stopMessagesPolling() {
+        if (this.msgPollTimer) {
+            clearInterval(this.msgPollTimer);
+            this.msgPollTimer = null;
+        }
     }
 
     async loadConversations() {
         const list = document.getElementById('conversationsList');
         if (!list) return;
         try {
-            const response = await fetch(`${this.apiBase}/messages/conversations`, { headers: this.authHeaders() });
+            const response = await fetch(`${this.apiBase}/messages/conversations`, { headers: this.authHeaders(), cache: 'no-store' });
             if (!response.ok) throw new Error('Failed to load conversations');
             const data = await response.json();
             this.conversations = data.conversations || [];
-            this.renderConversations();
+            // Skip the re-render when nothing changed so background polls don't
+            // rebuild the list under the user's cursor.
+            const fp = JSON.stringify(this.conversations.map(c =>
+                [c.other_user?.user_id, c.listing_id, c.last_message_at, c.unread_count]
+            ));
+            if (fp !== this._convFingerprint) {
+                this._convFingerprint = fp;
+                this.renderConversations();
+            }
         } catch (error) {
             console.error('Failed to load conversations:', error);
             list.innerHTML = this.emptyState('Could not load messages', 'Please try again later.');
@@ -1903,7 +2025,10 @@ class TradingHub {
         this.loadThread();
     }
 
-    async loadThread() {
+    // Load (or silently re-poll) the active thread. `silent` skips the loading
+    // placeholder and only re-renders when new messages arrived, so the poll
+    // doesn't flicker the view or jump the scroll position.
+    async loadThread({ silent = false } = {}) {
         if (!this.activeThread) return;
         const empty = document.getElementById('threadEmpty');
         const active = document.getElementById('threadActive');
@@ -1914,20 +2039,27 @@ class TradingHub {
         if (empty) empty.style.display = 'none';
         active.style.display = '';
         if (header) header.textContent = this.activeThread.name;
-        messagesEl.innerHTML = '<div class="thread-loading">Loading…</div>';
+        if (!silent) messagesEl.innerHTML = '<div class="thread-loading">Loading…</div>';
 
         try {
             const params = new URLSearchParams({ with_user_id: this.activeThread.userId });
             if (this.activeThread.listingId) params.set('listing_id', this.activeThread.listingId);
-            const response = await fetch(`${this.apiBase}/messages?${params}`, { headers: this.authHeaders() });
+            const response = await fetch(`${this.apiBase}/messages?${params}`, { headers: this.authHeaders(), cache: 'no-store' });
             if (!response.ok) throw new Error('Failed to load messages');
             const data = await response.json();
-            this.renderThread(data.messages || []);
+            const messages = data.messages || [];
+
+            const last = messages[messages.length - 1];
+            const fp = `${this.activeThread.userId}:${this.activeThread.listingId}:${messages.length}:${last?.id ?? 0}`;
+            if (silent && fp === this._threadFingerprint) return;
+            this._threadFingerprint = fp;
+
+            this.renderThread(messages);
             // Server marks incoming messages read on fetch — refresh unread badges.
             this.refreshBadges();
         } catch (error) {
             console.error('Failed to load thread:', error);
-            messagesEl.innerHTML = '<div class="thread-loading">Could not load messages.</div>';
+            if (!silent) messagesEl.innerHTML = '<div class="thread-loading">Could not load messages.</div>';
         }
     }
 

--- a/migrations/026_normalize_trade_user_ids.sql
+++ b/migrations/026_normalize_trade_user_ids.sql
@@ -1,0 +1,62 @@
+-- Normalize user ids stored in the trading tables.
+--
+-- The trade tables store user ids as TEXT while users.user_id is INTEGER.
+-- Ids that were read from D1 as numbers and re-inserted into a TEXT column
+-- picked up a float artifact ("137377499.0" instead of "137377499"), which
+-- broke every exact-match lookup: My Trades came back empty, message threads
+-- lost their history, unread counts stayed at zero and messages could never
+-- be marked read.
+--
+-- User ids are digit strings, so the only '.0' a legacy value can contain is
+-- the trailing float artifact — CAST to INTEGER and back strips it safely.
+
+UPDATE trade_listings
+SET user_id = CAST(CAST(user_id AS INTEGER) AS TEXT)
+WHERE user_id LIKE '%.0';
+
+UPDATE trade_offers
+SET from_user_id = CAST(CAST(from_user_id AS INTEGER) AS TEXT)
+WHERE from_user_id LIKE '%.0';
+
+UPDATE trade_offers
+SET to_user_id = CAST(CAST(to_user_id AS INTEGER) AS TEXT)
+WHERE to_user_id LIKE '%.0';
+
+UPDATE trade_messages
+SET from_user_id = CAST(CAST(from_user_id AS INTEGER) AS TEXT)
+WHERE from_user_id LIKE '%.0';
+
+UPDATE trade_messages
+SET to_user_id = CAST(CAST(to_user_id AS INTEGER) AS TEXT)
+WHERE to_user_id LIKE '%.0';
+
+UPDATE trade_notifications
+SET user_id = CAST(CAST(user_id AS INTEGER) AS TEXT)
+WHERE user_id LIKE '%.0';
+
+UPDATE trade_reviews
+SET reviewer_id = CAST(CAST(reviewer_id AS INTEGER) AS TEXT)
+WHERE reviewer_id LIKE '%.0';
+
+UPDATE trade_reviews
+SET reviewed_user_id = CAST(CAST(reviewed_user_id AS INTEGER) AS TEXT)
+WHERE reviewed_user_id LIKE '%.0';
+
+UPDATE completed_trades
+SET seller_id = CAST(CAST(seller_id AS INTEGER) AS TEXT)
+WHERE seller_id LIKE '%.0';
+
+UPDATE completed_trades
+SET buyer_id = CAST(CAST(buyer_id AS INTEGER) AS TEXT)
+WHERE buyer_id LIKE '%.0';
+
+-- user_trade_stats has user_id as its primary key: a user may have rows under
+-- both encodings. Drop the '.0' duplicate where a clean row already exists,
+-- then rename the remainder.
+DELETE FROM user_trade_stats
+WHERE user_id LIKE '%.0'
+  AND CAST(CAST(user_id AS INTEGER) AS TEXT) IN (SELECT user_id FROM user_trade_stats);
+
+UPDATE user_trade_stats
+SET user_id = CAST(CAST(user_id AS INTEGER) AS TEXT)
+WHERE user_id LIKE '%.0';

--- a/trading.html
+++ b/trading.html
@@ -123,9 +123,7 @@
                     <div class="trade-card skeleton"><div class="skeleton-inner"></div></div>
                 </div>
 
-                <div class="load-more-container" id="loadMoreContainer" style="display:none">
-                    <button class="btn-load-more" id="loadMoreBtn">Load More</button>
-                </div>
+                <nav class="pagination-container" id="paginationContainer" style="display:none" aria-label="Trade pages"></nav>
             </div>
 
             <!-- ============ MY TRADES PANEL ============ -->


### PR DESCRIPTION
## Summary
This PR replaces the "Load More" infinite scroll pattern with numbered pagination for the browse feed, adds automatic background polling to keep feeds fresh, and fixes critical user ID normalization issues that broke message threads and trade lookups.

## Key Changes

### Pagination Overhaul
- Replaced offset-based "Load More" button with numbered page buttons (first/last always visible, ±1 around current page, gaps collapsed to ellipsis)
- Changed from `browseOffset`/`browseHasMore` to `browsePage`/`browseTotal` to track pages and total row count
- Server now returns total count in listings API response, enabling proper pagination UI
- Added `goToPage()` method with smooth scroll to top of new page
- Updated `loadTrades()` to accept page number instead of reset flag

### Auto-Refresh & Polling
- Added `startAutoRefresh()` that polls active feed (browse/my-trades) every 30 seconds
- Implemented fingerprinting (`_browseFingerprint`, `_myTradesFingerprint`) to skip re-renders when data hasn't changed, preventing UI jank during background polls
- Added `startMessagesPolling()` that polls conversations and active thread every 10 seconds while messages modal is open
- Polls respect tab visibility (skip when tab is hidden, catch up immediately on return)

### User ID Normalization Fix
- Added `normalizeUserId()`, `userIdForms()`, and `isSameUser()` helpers to handle legacy float-artifact IDs ("137377499.0")
- Trade tables store user IDs as TEXT while `users.user_id` is INTEGER; D1 number binds created ".0" suffixes that broke exact-match lookups
- Updated all API endpoints (listings, offers, messages, reviews, notifications, completed trades) to query both canonical and legacy ID forms
- Added migration `026_normalize_trade_user_ids.sql` to clean up existing data
- Normalized user IDs in all API responses

### Search Improvements
- Extended item search to match against item names in JSON columns (`offering_items`, `seeking_items`), not just title/description
- Updated client-side search filter to mirror server behavior

### UI/UX Refinements
- Improved "Make Offer" modal styling with better field labels and search results dropdown
- Refactored custom item modal opening to use shared `openCustomModal()` method
- Updated stats calculation to use server total for active trades when status filter is active

## Notable Implementation Details
- Fingerprinting uses JSON stringification of key fields to detect changes without deep equality checks
- Pagination buttons use `data-page` attributes for event delegation
- Background polls check `document.visibilityState` to avoid unnecessary work when tab is hidden
- Migration safely handles duplicate user_trade_stats rows by deleting ".0" variants where clean versions exist

https://claude.ai/code/session_01H3iMfPScK6tiEF8yWmbEHo