### PR TITLE
Add item size slider and category colors to trades

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -82,6 +82,24 @@
             <!-- Stats Dashboard -->
             <button class="stats-btn" onclick="catalog.openStats()">My Lists</button>
 
+            <!-- Item Size Slider -->
+            <div class="item-size-control" title="Resize items">
+                <span class="size-icon small" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+                        stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="6" y="6" width="12" height="12" rx="2"></rect>
+                    </svg>
+                </span>
+                <input id="item-size-slider" class="item-size-slider" type="range" min="80" max="170" step="1"
+                    value="110" aria-label="Item size" />
+                <span class="size-icon large" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+                    </svg>
+                </span>
+            </div>
+
             <!-- Filters Dropdown -->
             <div class="filters-dropdown">
                 <button class="dropdown-btn" onclick="catalog.toggleFilters()">

--- a/css/style.css
+++ b/css/style.css
@@ -712,10 +712,10 @@ main {
     cursor: pointer;
     transition: all 0.3s var(--ease-spring);
     position: relative;
-    min-height: 110px;
-    min-width: 110px;
-    max-height: 110px;
-    max-width: 110px;
+    min-height: var(--item-size, 110px);
+    min-width: var(--item-size, 110px);
+    max-height: var(--item-size, 110px);
+    max-width: var(--item-size, 110px);
     box-shadow: 0 0px 0px var(--shadow-color), inset -2px -2px 4px var(--edges-color);
     display: flex;
     border: 1px solid var(--border-color);
@@ -750,8 +750,8 @@ main {
 }
 
 .item:hover::before {
-    width: 90px;
-    height: 90px;
+    width: calc(var(--item-size, 110px) * 0.82);
+    height: calc(var(--item-size, 110px) * 0.82);
 }
 
 .item:hover {
@@ -1507,7 +1507,7 @@ footer {
 
 .catalog-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(var(--item-size, 110px), 1fr));
     /* even, roomier spacing so the grid reads as tidy rows, not a dense wall */
     gap: 22px 20px;
     animation: fadeIn 0.5s;
@@ -2291,6 +2291,75 @@ textarea {
 
 .dropdown-btn:hover {
     background: var(--border-color);
+}
+
+/* Item size slider — lets users scale catalog cards bigger/smaller. */
+.item-size-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: var(--bg-item);
+    border: 2px solid var(--border-color);
+    border-radius: 25px;
+    transition: all 0.3s;
+}
+
+.item-size-control:hover {
+    background: var(--border-color);
+}
+
+.item-size-control .size-icon {
+    color: var(--text-secondary);
+    display: inline-flex;
+    flex-shrink: 0;
+    pointer-events: none;
+}
+
+.item-size-control .size-icon.small svg {
+    width: 12px;
+    height: 12px;
+}
+
+.item-size-control .size-icon.large svg {
+    width: 18px;
+    height: 18px;
+}
+
+.item-size-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 110px;
+    height: 6px;
+    border-radius: 6px;
+    background: var(--border-color);
+    outline: none;
+    cursor: pointer;
+}
+
+.item-size-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent, #4a9eff);
+    border: 2px solid var(--bg-1);
+    cursor: pointer;
+    transition: transform 0.15s ease;
+}
+
+.item-size-slider::-webkit-slider-thumb:hover {
+    transform: scale(1.15);
+}
+
+.item-size-slider::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent, #4a9eff);
+    border: 2px solid var(--bg-1);
+    cursor: pointer;
 }
 
 .tag-count {

--- a/css/trading.css
+++ b/css/trading.css
@@ -521,6 +521,29 @@
     flex-shrink: 0;
 }
 
+/* Category-coloured tiles behind trade/offer thumbnails — mirrors the catalog
+   card backgrounds so items read the same in both places. */
+.trade-item-img.cat-gear,
+.trade-item-img.cat-death,
+.trade-item-img.cat-effect,
+.trade-item-img.cat-title,
+.trade-item-img.cat-pet,
+.detail-item .cat-gear,
+.detail-item .cat-death,
+.detail-item .cat-effect,
+.detail-item .cat-title,
+.detail-item .cat-pet {
+    box-sizing: border-box;
+    padding: 3px;
+    border-radius: 8px;
+}
+
+.cat-gear { background: #5bfe6a; }
+.cat-death { background: #ff7a5e; }
+.cat-effect { background: #ffb135; }
+.cat-title { background: #c960fe; }
+.cat-pet { background: #377afa; }
+
 /* SVG artwork thumb (titles) — sized like the <img> it replaces, wider box
    because titles are horizontal text art */
 .item-svg-thumb {

--- a/js/components/item-card.js
+++ b/js/components/item-card.js
@@ -35,6 +35,22 @@ const CATEGORY_IDS = {
     titles: 'title'
 };
 
+// Category → background class for trade/offer thumbnails, so trade items carry
+// the same colour coding as catalog cards. Accepts both the plural catalog
+// category ("gears") and the singular id ("gear").
+const CATEGORY_BG_CLASS = {
+    gears: 'cat-gear', gear: 'cat-gear',
+    deaths: 'cat-death', death: 'cat-death',
+    pets: 'cat-pet', pet: 'cat-pet',
+    effects: 'cat-effect', effect: 'cat-effect',
+    titles: 'cat-title', title: 'cat-title'
+};
+
+function categoryBgClass(category) {
+    if (!category) return '';
+    return CATEGORY_BG_CLASS[String(category).toLowerCase()] || '';
+}
+
 /**
  * Build a catalog item card.
  * @param {object} item
@@ -200,7 +216,7 @@ export function itemVisualHTML(imgSrc, svg, name, className = '') {
  * variant 'detail'         → .detail-item in the trade detail modal.
  * opts.svg — catalog SVG markup for imageless items (titles).
  */
-export function tradeItemHTML(item, { variant = 'card', svg = null } = {}) {
+export function tradeItemHTML(item, { variant = 'card', svg = null, category = null } = {}) {
     const esc = Utils.escapeHtml;
     const qty = item.qty && item.qty > 1 ? `<span class="item-qty-badge">×${item.qty}</span>` : '';
 
@@ -210,17 +226,19 @@ export function tradeItemHTML(item, { variant = 'card', svg = null } = {}) {
     if (item.type === 'other-game') {
         return `<div class="trade-item-other">${esc(item.game_name)}: ${esc(item.item_name)}${qty}</div>`;
     }
+    const catClass = categoryBgClass(category ?? item.category);
     if (variant === 'detail') {
         return `
             <div class="detail-item">
-                ${itemVisualHTML(item.item_image, svg, item.item_name)}
+                ${itemVisualHTML(item.item_image, svg, item.item_name, catClass)}
                 <span>${esc(item.item_name)}${qty}</span>
             </div>
         `;
     }
+    const imgClass = catClass ? `trade-item-img ${catClass}` : 'trade-item-img';
     return `
         <div class="trade-item">
-            ${itemVisualHTML(item.item_image, svg, item.item_name, 'trade-item-img')}
+            ${itemVisualHTML(item.item_image, svg, item.item_name, imgClass)}
             <span class="trade-item-name">${esc(item.item_name)}${qty}</span>
         </div>
     `;

--- a/js/pages/catalog.js
+++ b/js/pages/catalog.js
@@ -1418,6 +1418,31 @@
                     // Restore filters from URL
                     this.handleURLParams(true);
                 });
+
+                this.initItemSize();
+            }
+
+            // Item size slider: scales catalog cards via the --item-size CSS
+            // variable on the grid, and remembers the choice across visits.
+            initItemSize() {
+                const slider = document.getElementById('item-size-slider');
+                if (!slider) return;
+
+                const saved = parseInt(Utils.loadFromStorage('catalogItemSize', slider.value), 10);
+                const size = Number.isFinite(saved) ? saved : parseInt(slider.value, 10);
+                slider.value = size;
+                this.applyItemSize(size);
+
+                slider.addEventListener('input', (e) => {
+                    const value = parseInt(e.target.value, 10);
+                    this.applyItemSize(value);
+                    Utils.saveToStorage('catalogItemSize', value);
+                });
+            }
+
+            applyItemSize(px) {
+                const grid = document.getElementById('catalog');
+                if (grid) grid.style.setProperty('--item-size', `${px}px`);
             }
 
             updateTagCounts() {

--- a/js/pages/home.js
+++ b/js/pages/home.js
@@ -120,7 +120,12 @@
 						Object.entries(outlineColors).forEach(([num, color]) => {
 							if (priceCodeRarity.toLowerCase().includes(num)) {
 								div.style.outline = `4px solid ${color}`;
-								div.style.background = 'unset';
+								// In the "New Items" section, keep the item's category
+								// background instead of clearing it — star-shop items that
+								// are also new shouldn't read as transparent tiles there.
+								if (gridId !== 'new-items-grid') {
+									div.style.background = 'unset';
+								}
 							}
 						});
 

--- a/js/trading.js
+++ b/js/trading.js
@@ -203,6 +203,13 @@ class TradingHub {
         return this.itemsByName.get(String(name).toLowerCase())?.svg || null;
     }
 
+    // Catalog category for an item name, so trade thumbnails can carry the same
+    // colour coding as catalog cards.
+    categoryFor(name) {
+        if (!name || !this.itemsByName) return null;
+        return this.itemsByName.get(String(name).toLowerCase())?.category || null;
+    }
+
     // API listing row → the trade shape the UI renders.
     mapListing(listing) {
         return {
@@ -1119,7 +1126,10 @@ class TradingHub {
 
     // Small "×N" badge for stacked items (only shown when qty > 1).
     renderTradeItem(item) {
-        return window.ItemCard.tradeItemHTML(item, { svg: this.svgFor(item.item_name) });
+        return window.ItemCard.tradeItemHTML(item, {
+            svg: this.svgFor(item.item_name),
+            category: item.category || this.categoryFor(item.item_name)
+        });
     }
 
     // Item chips for a trade card side, capped so one huge trade can't stretch
@@ -1448,7 +1458,11 @@ class TradingHub {
     }
 
     renderDetailItem(item) {
-        return window.ItemCard.tradeItemHTML(item, { variant: 'detail', svg: this.svgFor(item.item_name) });
+        return window.ItemCard.tradeItemHTML(item, {
+            variant: 'detail',
+            svg: this.svgFor(item.item_name),
+            category: item.category || this.categoryFor(item.item_name)
+        });
     }
 
     closeDetailModal() {


### PR DESCRIPTION
## Summary
This PR adds user-configurable item sizing to the catalog and applies category-based color coding to trade item thumbnails, improving visual consistency and customization across the app.

## Key Changes

- **Item Size Slider**: Added a new control in the catalog header that lets users resize catalog cards from 80px to 170px. The preference is persisted across sessions using local storage.
  - Introduced `--item-size` CSS variable to replace hardcoded 110px dimensions
  - Implemented `initItemSize()` and `applyItemSize()` methods in catalog.js
  - Added styled slider control with small/large icons in catalog.html

- **Category Color Coding for Trades**: Trade item thumbnails now display the same category background colors as catalog cards (gear, death, pet, effect, title).
  - Created `CATEGORY_BG_CLASS` mapping in item-card.js
  - Updated `tradeItemHTML()` to accept and apply category classes
  - Modified `TradingHub.renderTradeItem()` and `renderDetailItem()` to pass category information
  - Added `categoryFor()` method to TradingHub to look up item categories by name
  - Styled category backgrounds in trading.css with appropriate colors and padding

- **Home Page Fix**: Preserved category background colors on new items in the home page grid instead of clearing them when rarity outlines are applied.

## Implementation Details

- The item size slider uses CSS custom properties for dynamic scaling, affecting both individual item dimensions and grid layout
- Category colors are applied via CSS classes that can be combined with existing styling
- The slider value is stored as `catalogItemSize` in localStorage for persistence
- Trade items can receive category information either directly or by looking it up from the catalog data

https://claude.ai/code/session_01JX7yNhvn49j7ZSE5dAwK5H