### PR TITLE
Replace hover labels with cursor-following item tooltip

### DIFF
--- a/css/trading.css
+++ b/css/trading.css
@@ -562,30 +562,50 @@
     width: 64px;
 }
 
-.trade-item-name {
-    opacity: 0;
-    position: absolute;
-    top: calc(100% - 6px);
-    left: 50%;
-    transform: translateX(-50%);
-    background: linear-gradient(180deg, #5f5f5f, #97979763);
+/* Cursor-following tooltip for trade item thumbnails — names the hovered item
+   and shows its catalog value underneath. Lives on <body> (see
+   TradingHub.setupItemTooltip) so it can track the pointer across cards, and is
+   pointer-only: it never appears on touch/mobile. */
+.trade-item-tooltip {
+    position: fixed;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    max-width: 260px;
+    padding: 6px 9px;
     border-radius: 8px;
-    padding: 2px 4px;
-    font-weight: 600;
-    color: var(--text-secondary);
-    overflow: hidden;
-    text-overflow: ellipsis;
+    background: linear-gradient(180deg, #2b2b2b, #1b1b1b);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
     pointer-events: none;
     white-space: nowrap;
-    z-index: 2;
 }
 
-.trade-item:hover .trade-item-name {
-    opacity: 1;
+.trade-item-tooltip .tooltip-name {
+    font-weight: 700;
+    font-size: 0.82rem;
+    color: #fff;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-/* Always-visible "×N" quantity badge pinned to the lower-right of the thumbnail
-   (the inline badge inside .trade-item-name only shows on hover). */
+.trade-item-tooltip .tooltip-price {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--font-num, #6cd06c);
+}
+
+.light-theme .trade-item-tooltip {
+    background: linear-gradient(180deg, #ffffff, #f1f1f1);
+    border-color: rgba(0, 0, 0, 0.12);
+}
+
+.light-theme .trade-item-tooltip .tooltip-name {
+    color: #000;
+}
+
+/* Always-visible "×N" quantity badge pinned to the lower-right of the thumbnail. */
 .trade-item-qty {
     position: absolute;
     right: 0;

--- a/js/components/item-card.js
+++ b/js/components/item-card.js
@@ -233,7 +233,7 @@ export function itemVisualHTML(imgSrc, svg, name, className = '') {
  * variant 'detail'         → .detail-item in the trade detail modal.
  * opts.svg — catalog SVG markup for imageless items (titles).
  */
-export function tradeItemHTML(item, { variant = 'card', svg = null, category = null } = {}) {
+export function tradeItemHTML(item, { variant = 'card', svg = null, category = null, price = null } = {}) {
     const esc = Utils.escapeHtml;
     const qty = item.qty && item.qty > 1 ? `<span class="item-qty-badge">×${item.qty}</span>` : '';
 
@@ -256,11 +256,15 @@ export function tradeItemHTML(item, { variant = 'card', svg = null, category = n
     // Quantity sits in a corner badge on the thumbnail (always visible) rather
     // than inside the hover-only name, so ×N reads at a glance without hovering.
     const qtyCorner = item.qty && item.qty > 1 ? `<span class="trade-item-qty">×${item.qty}</span>` : '';
+    // The item's name and value ride on data attributes and surface through a
+    // single cursor-following tooltip (TradingHub.setupItemTooltip) instead of an
+    // inline label, so hovering any thumbnail names it at the pointer with its
+    // price underneath. The tooltip is pointer-only and stays off on touch/mobile.
+    const priceAttr = price ? ` data-item-price="${esc(price)}"` : '';
     return `
-        <div class="trade-item">
+        <div class="trade-item" data-item-name="${esc(item.item_name)}"${priceAttr}>
             ${itemVisualHTML(item.item_image, svg, item.item_name, imgClass)}
             ${qtyCorner}
-            <span class="trade-item-name">${esc(item.item_name)}</span>
         </div>
     `;
 }

--- a/js/trading.js
+++ b/js/trading.js
@@ -85,6 +85,7 @@ class TradingHub {
 
     async init() {
         this.setupEventListeners();
+        this.setupItemTooltip();
         this.applyAuthState();
         this.renderSortDropdown();
         await Promise.all([
@@ -208,6 +209,21 @@ class TradingHub {
     categoryFor(name) {
         if (!name || !this.itemsByName) return null;
         return this.itemsByName.get(String(name).toLowerCase())?.category || null;
+    }
+
+    // Catalog value for an item name, formatted for the hover tooltip. Returns
+    // null when the item has no known/priced value (unrated, N/A, O/C, or 0) so
+    // the tooltip just shows the name.
+    priceFor(name) {
+        if (!name || !this.itemsByName) return null;
+        const raw = this.itemsByName.get(String(name).toLowerCase())?.price;
+        if (raw === null || raw === undefined) return null;
+        const s = String(raw).trim();
+        if (!s || s === '0') return null;
+        const upper = s.toUpperCase();
+        if (upper === 'N/A' || upper === 'O/C') return null;
+        const formatted = window.Utils.formatPrice(raw);
+        return formatted ? `${formatted} value` : null;
     }
 
     // API listing row → the trade shape the UI renders.
@@ -1124,11 +1140,75 @@ class TradingHub {
         return card;
     }
 
+    // A single cursor-following tooltip, shared by every trade item thumbnail,
+    // that names the hovered item and shows its value underneath. Set up once and
+    // driven by delegated pointer events so it works for cards rendered later.
+    //
+    // Pointer-only by design: touch/mobile devices have no cursor to anchor the
+    // tooltip to, so on `(hover: none)`/coarse pointers we skip setup entirely and
+    // the feature stays disabled — matching the requested mobile behaviour.
+    setupItemTooltip() {
+        if (this._itemTooltip) return;
+        if (!window.matchMedia || !window.matchMedia('(hover: hover) and (pointer: fine)').matches) return;
+
+        const tip = document.createElement('div');
+        tip.className = 'trade-item-tooltip';
+        tip.setAttribute('role', 'tooltip');
+        tip.style.display = 'none';
+        document.body.appendChild(tip);
+        this._itemTooltip = tip;
+
+        let current = null;
+
+        const hide = () => {
+            current = null;
+            tip.style.display = 'none';
+        };
+
+        // Keep the tooltip beside the cursor and clamp it inside the viewport so
+        // it never gets clipped at the right/bottom edges.
+        const position = (e) => {
+            const pad = 14;
+            const rect = tip.getBoundingClientRect();
+            let x = e.clientX + pad;
+            let y = e.clientY + pad;
+            if (x + rect.width > window.innerWidth) x = e.clientX - pad - rect.width;
+            if (y + rect.height > window.innerHeight) y = e.clientY - pad - rect.height;
+            tip.style.left = `${Math.max(0, x)}px`;
+            tip.style.top = `${Math.max(0, y)}px`;
+        };
+
+        document.addEventListener('mouseover', (e) => {
+            const el = e.target.closest?.('.trade-item[data-item-name]');
+            if (!el || el === current) return;
+            current = el;
+            const name = el.getAttribute('data-item-name') || '';
+            const price = el.getAttribute('data-item-price') || '';
+            tip.innerHTML = `<span class="tooltip-name">${this.esc(name)}</span>`
+                + (price ? `<span class="tooltip-price">${this.esc(price)}</span>` : '');
+            tip.style.display = 'flex';
+            position(e);
+        });
+
+        document.addEventListener('mousemove', (e) => {
+            if (!current) return;
+            if (!e.target.closest?.('.trade-item[data-item-name]')) { hide(); return; }
+            position(e);
+        });
+
+        // Hide when the pointer leaves the thumbnail (or the page/scroll changes).
+        document.addEventListener('mouseout', (e) => {
+            if (current && !e.relatedTarget?.closest?.('.trade-item[data-item-name]')) hide();
+        });
+        window.addEventListener('scroll', hide, true);
+    }
+
     // Small "×N" badge for stacked items (only shown when qty > 1).
     renderTradeItem(item) {
         return window.ItemCard.tradeItemHTML(item, {
             svg: this.svgFor(item.item_name),
-            category: item.category || this.categoryFor(item.item_name)
+            category: item.category || this.categoryFor(item.item_name),
+            price: this.priceFor(item.item_name)
         });
     }
 


### PR DESCRIPTION
## Summary
Replaces the static hover-only item name labels with a single cursor-following tooltip that displays both the item name and its catalog value. The tooltip is pointer-only and disabled on touch/mobile devices to match the requested mobile behavior.

## Key Changes
- **New tooltip system**: Added `setupItemTooltip()` method that creates a single shared tooltip element on `<body>` driven by delegated pointer events, allowing it to work with dynamically rendered cards
- **Price formatting**: Implemented `priceFor()` method to extract and format item catalog values, filtering out unpriced items (N/A, O/C, unrated, or 0 values)
- **Data attributes**: Modified `tradeItemHTML()` to store item name and price on `data-item-name` and `data-item-price` attributes instead of rendering inline labels
- **Pointer-only design**: Tooltip only activates on devices with `(hover: hover) and (pointer: fine)` media query match, automatically disabling on touch/coarse pointer devices
- **Styling overhaul**: Replaced `.trade-item-name` hover label styles with new `.trade-item-tooltip` fixed-position tooltip with improved visual hierarchy, dark/light theme support, and viewport edge clamping
- **Tooltip positioning**: Implements smart positioning logic that keeps the tooltip beside the cursor while clamping it inside the viewport to prevent clipping at right/bottom edges

## Implementation Details
- The tooltip uses `position: fixed` and `z-index: 1000` to float above all content
- Delegated event listeners on `document` handle `mouseover`, `mousemove`, and `mouseout` to track the current hovered item
- Tooltip hides on scroll or when pointer leaves the trade item element
- Price display uses the existing `window.Utils.formatPrice()` utility for consistent formatting
- HTML content is escaped via `this.esc()` to prevent injection vulnerabilities

https://claude.ai/code/session_01KNA8JGTYu7m5nR4cXbR6kF