### PR TITLE
Add 'donator' role support to role update endpoint

### DIFF
--- a/functions/api/auth/[[path]].js
+++ b/functions/api/auth/[[path]].js
@@ -241,7 +241,7 @@ async function handleUpdateRole(request, env) {
 
     const { userId, role, action } = await request.json(); // action: 'add' or 'remove'
 
-    if (!['user', 'vip', 'moderator', 'admin'].includes(role)) {
+    if (!['user', 'vip', 'moderator', 'admin', 'donator'].includes(role)) {
         return new Response(JSON.stringify({ error: 'Invalid role' }), {
             status: 400,
             headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Summary
Added support for a new 'donator' role in the role management system by updating the role validation logic in the auth API endpoint.

## Key Changes
- Extended the role validation list in `handleUpdateRole()` to include 'donator' as a valid role alongside existing roles (user, vip, moderator, admin)

## Implementation Details
The change allows the role update endpoint to accept 'donator' as a valid role when users attempt to add or remove this role. This enables the system to manage a new user tier for donors/supporters.

https://claude.ai/code/session_01DRzS5k1yPAaA443r9QkteX