### PR TITLE
Add likes, blocks, bans, and moderation to trading system

### DIFF
--- a/css/trading.css
+++ b/css/trading.css
@@ -2909,3 +2909,86 @@ content: '';
         animation: none;
     }
 }
+
+/* ==================== Likes, block & moderation controls ==================== */
+
+/* Heart "like" button on trade cards and in the detail modal. */
+.btn-like {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-item-hover);
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.2s;
+    min-height: 38px;
+}
+
+.btn-like:hover {
+    border-color: #e0245e;
+    color: #e0245e;
+    transform: translateY(-1px);
+}
+
+.btn-like.liked {
+    border-color: #e0245e;
+    color: #e0245e;
+    background: color-mix(in srgb, #e0245e 12%, transparent);
+}
+
+.btn-like .like-count { font-variant-numeric: tabular-nums; }
+
+/* In the detail meta row the like button stays compact and pushes the status
+   badge to the right. */
+.detail-meta { align-items: center; }
+.detail-meta .btn-like { padding: 0.3rem 0.55rem; min-height: 30px; }
+.detail-meta .trade-status-badge { margin-left: auto; }
+
+/* Moderator "Remove" button on trade cards. */
+.btn-mod-delete {
+    padding: 0.5rem 0.7rem;
+    border: 1px solid #810000;
+    border-radius: 8px;
+    background: var(--danger-gradient);
+    color: #fff;
+    font-size: 0.8rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.2s;
+    min-height: 38px;
+}
+.btn-mod-delete:hover { filter: brightness(1.08) saturate(1.05); transform: translateY(-1px); }
+
+/* Thread header: name on the left, Block button on the right. */
+.thread-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+.thread-header-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.thread-header-block {
+    flex: 0 0 auto;
+    padding: 0.35rem 0.7rem;
+    border-radius: 8px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    min-height: 30px;
+}
+
+/* Blocked users list (My Trades → Blocked). */
+.blocked-card .conv-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+}

--- a/docs/TRADING_SYSTEM.md
+++ b/docs/TRADING_SYSTEM.md
@@ -34,7 +34,7 @@ The trading system allows users to:
 
 ### Database Schema
 
-The system uses 7 main tables:
+The system uses these main tables:
 
 1. **trade_listings** - Public trade listings
 2. **trade_offers** - Offers made on listings
@@ -43,10 +43,14 @@ The system uses 7 main tables:
 5. **trade_reviews** - Reputation system
 6. **user_trade_stats** - Aggregate statistics
 7. **trade_notifications** - In-app notifications
+8. **trade_blocks** - A user blocking another (stops offers/messages)
+9. **trade_bans** - Players banned from trading by an admin/mod
+10. **trade_likes** - Likes on trade listings (replaces the old view counter)
 
-See `migrations/023_create_trading_tables.sql` for the complete schema. The
-migration is idempotent (`CREATE TABLE IF NOT EXISTS`), so it is safe to run
-even if some tables were created previously.
+See `migrations/023_create_trading_tables.sql` for the base schema and
+`migrations/027_trade_blocks_bans_likes.sql` for the blocks/bans/likes tables.
+Both migrations are idempotent (`CREATE TABLE IF NOT EXISTS`), so they are safe
+to run even if some tables were created previously.
 
 ## Database Setup
 
@@ -84,7 +88,7 @@ List all trade listings
 - `search` - Search in title/description
 - `limit` - Results per page (default: 20, max: 100)
 - `offset` - Pagination offset
-- `sort` - Sort field (created_at, updated_at, views)
+- `sort` - Sort field (created_at, updated_at, likes)
 - `order` - Sort order (ASC, DESC)
 
 **Response:**
@@ -108,7 +112,8 @@ List all trade listings
       "seeking_items": [],
       "created_at": 1234567890000,
       "updated_at": 1234567890000,
-      "views": 15,
+      "like_count": 15,
+      "liked": false,
       "user": {
         "user_id": "123456",
         "username": "CoolTrader",
@@ -453,6 +458,53 @@ Mark all notifications as read
 Delete notification
 
 **Authentication Required:** Yes
+
+### Likes
+
+#### POST /api/trades/listings/:id/like
+Toggle the signed-in user's like on a listing.
+
+**Authentication Required:** Yes
+
+**Response:** `{ "liked": true, "like_count": 16 }`
+
+Listing responses (`GET /api/trades/listings` and `GET /api/trades/listings/:id`)
+include `like_count` (total) and `liked` (whether the current viewer liked it).
+Views are no longer tracked.
+
+### Blocks
+
+A block is directional: the blocker stops receiving offers and messages from the
+blocked user.
+
+#### GET /api/trades/blocks
+List the users the signed-in user has blocked.
+
+#### POST /api/trades/blocks
+Block a user. Body: `{ "user_id": "123" }`
+
+#### DELETE /api/trades/blocks/:userId
+Unblock a user.
+
+**Authentication Required:** Yes (all block endpoints)
+
+### Moderation (admin / mod only)
+
+Roles that moderate: `admin`, `owner`, `moderator`, `mod`.
+
+#### DELETE /api/trades/listings/:id
+Owners soft-cancel their own listing; moderators hard-delete any listing
+(also removing its likes and offers).
+
+#### POST /api/trades/admin/ban
+Ban a player from trading. Body: `{ "user_id": "123", "reason": "..." }`.
+Banned players cannot create listings, make offers, or send messages.
+
+#### DELETE /api/trades/admin/ban/:userId
+Lift a trading ban.
+
+#### GET /api/trades/admin/bans
+List banned players.
 
 ## Frontend Integration
 

--- a/functions/api/trades/_utils/helpers.js
+++ b/functions/api/trades/_utils/helpers.js
@@ -48,12 +48,50 @@ export async function authenticateUser(request, env) {
     return user || null;
 }
 
-// Check if user is authorized (authenticated and not banned)
+// Parse the raw `roles` value (JSON string, array, or single string) attached
+// to an authenticated user into a lowercased string array.
+export function parseRoles(user) {
+    let roles = user?.roles;
+    if (!roles) return [];
+    if (typeof roles === 'string') {
+        try { roles = JSON.parse(roles); } catch { roles = [roles]; }
+    }
+    if (!Array.isArray(roles)) return [];
+    return roles.map(r => String(r).toLowerCase());
+}
+
+// Roles that can moderate the trading system (delete any listing, ban players).
+const MODERATOR_ROLES = ['admin', 'owner', 'moderator', 'mod'];
+
+// True when the authenticated user holds an admin/moderator role.
+export function isModerator(user) {
+    if (!user) return false;
+    return parseRoles(user).some(r => MODERATOR_ROLES.includes(r));
+}
+
+// Check if user is authorized (authenticated and not a flagged scammer)
 export function isAuthorized(user) {
     if (!user) return false;
+    return !parseRoles(user).includes('scammer');
+}
 
-    const roles = typeof user.roles === 'string' ? JSON.parse(user.roles) : user.roles;
-    return !roles.includes('scammer');
+// True when `userId` has been banned from trading by an admin/mod.
+export async function isTradeBanned(env, userId) {
+    const row = await env.DBA.prepare(
+        'SELECT user_id FROM trade_bans WHERE user_id IN (?, ?)'
+    ).bind(...userIdForms(userId)).first();
+    return !!row;
+}
+
+// True when `ownerId` has blocked `otherId` (so `otherId` may not send them
+// offers or messages). Direction matters: only the blocker is protected.
+export async function isBlockedBy(env, ownerId, otherId) {
+    const ownerForms = userIdForms(ownerId);
+    const otherForms = userIdForms(otherId);
+    const row = await env.DBA.prepare(
+        'SELECT id FROM trade_blocks WHERE blocker_id IN (?, ?) AND blocked_id IN (?, ?)'
+    ).bind(...ownerForms, ...otherForms).first();
+    return !!row;
 }
 
 // Standard error response

--- a/functions/api/trades/admin/[[path]].js
+++ b/functions/api/trades/admin/[[path]].js
@@ -1,0 +1,149 @@
+import {
+    authenticateUser,
+    isModerator,
+    errorResponse,
+    successResponse,
+    validateFields,
+    getUserWithStats,
+    normalizeUserId,
+    userIdForms
+} from '../_utils/helpers.js';
+
+// GET /api/trades/admin/bans - list banned players (moderators only)
+async function handleGet(env, path, user) {
+    if (!isModerator(user)) {
+        return errorResponse('Forbidden', 403);
+    }
+
+    if (path === 'bans') {
+        const { results } = await env.DBA.prepare(
+            'SELECT user_id, banned_by, reason, created_at FROM trade_bans ORDER BY created_at DESC'
+        ).all();
+
+        const bans = await Promise.all((results || []).map(async (row) => {
+            const info = await getUserWithStats(env, row.user_id);
+            return {
+                user_id: normalizeUserId(row.user_id),
+                reason: row.reason,
+                created_at: row.created_at,
+                banned_by: normalizeUserId(row.banned_by),
+                username: info?.username || null,
+                display_name: info?.display_name || null,
+                avatar_url: info?.avatar_url || null
+            };
+        }));
+
+        return successResponse({ bans });
+    }
+
+    return errorResponse('Invalid request', 400);
+}
+
+// POST /api/trades/admin/ban - ban a player from trading (moderators only)
+async function handlePost(request, env, path, user) {
+    if (!isModerator(user)) {
+        return errorResponse('Forbidden', 403);
+    }
+
+    if (path === 'ban') {
+        const data = await request.json();
+        const error = validateFields(data, ['user_id']);
+        if (error) {
+            return errorResponse(error);
+        }
+
+        const targetId = normalizeUserId(data.user_id);
+
+        // Don't allow banning a fellow moderator/admin.
+        const target = await getUserWithStats(env, targetId);
+        if (target && isModerator({ roles: target.roles })) {
+            return errorResponse('Cannot ban a moderator or admin', 403);
+        }
+
+        await env.DBA.prepare(
+            `INSERT INTO trade_bans (user_id, banned_by, reason, created_at)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(user_id) DO UPDATE SET
+                banned_by = excluded.banned_by,
+                reason = excluded.reason,
+                created_at = excluded.created_at`
+        ).bind(targetId, normalizeUserId(user.user_id), data.reason || null, Date.now()).run();
+
+        return successResponse({ message: 'Player banned from trading', user_id: targetId }, 201);
+    }
+
+    return errorResponse('Invalid request', 400);
+}
+
+// DELETE /api/trades/admin/ban/:userId - lift a trading ban (moderators only)
+async function handleDelete(env, path, user) {
+    if (!isModerator(user)) {
+        return errorResponse('Forbidden', 403);
+    }
+
+    const parts = path.split('/');
+    if (parts[0] === 'ban' && parts[1]) {
+        const targetId = normalizeUserId(parts[1]);
+        await env.DBA.prepare(
+            'DELETE FROM trade_bans WHERE user_id IN (?, ?)'
+        ).bind(...userIdForms(targetId)).run();
+
+        return successResponse({ message: 'Ban lifted', user_id: targetId });
+    }
+
+    return errorResponse('Invalid request', 400);
+}
+
+export async function onRequest(context) {
+    const { request, env } = context;
+    const url = new URL(request.url);
+    const prefix = '/api/trades/admin';
+    const path = url.pathname.startsWith(prefix)
+        ? url.pathname.slice(prefix.length).replace(/^\//, '')
+        : '';
+
+    const corsHeaders = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    };
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { headers: corsHeaders });
+    }
+
+    try {
+        const user = await authenticateUser(request, env);
+        if (!user) {
+            return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+                status: 401,
+                headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+            });
+        }
+
+        let response;
+        switch (request.method) {
+            case 'GET':
+                response = await handleGet(env, path, user);
+                break;
+            case 'POST':
+                response = await handlePost(request, env, path, user);
+                break;
+            case 'DELETE':
+                response = await handleDelete(env, path, user);
+                break;
+            default:
+                response = errorResponse('Method not allowed', 405);
+        }
+
+        const headers = new Headers(response.headers);
+        Object.entries(corsHeaders).forEach(([key, value]) => headers.set(key, value));
+        return new Response(response.body, { status: response.status, headers });
+    } catch (error) {
+        console.error('Trade admin error:', error);
+        return new Response(JSON.stringify({ error: 'Internal server error' }), {
+            status: 500,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+    }
+}

--- a/functions/api/trades/blocks/[[path]].js
+++ b/functions/api/trades/blocks/[[path]].js
@@ -1,0 +1,126 @@
+import {
+    authenticateUser,
+    isAuthorized,
+    errorResponse,
+    successResponse,
+    validateFields,
+    getUserWithStats,
+    normalizeUserId,
+    userIdForms,
+    isSameUser
+} from '../_utils/helpers.js';
+
+// GET /api/trades/blocks - list the users the signed-in user has blocked
+async function handleGet(env, user) {
+    if (!user || !isAuthorized(user)) {
+        return errorResponse('Unauthorized', 401);
+    }
+
+    const { results } = await env.DBA.prepare(
+        'SELECT blocked_id, created_at FROM trade_blocks WHERE blocker_id IN (?, ?) ORDER BY created_at DESC'
+    ).bind(...userIdForms(user.user_id)).all();
+
+    const blocked = await Promise.all((results || []).map(async (row) => {
+        const info = await getUserWithStats(env, row.blocked_id);
+        return {
+            user_id: normalizeUserId(row.blocked_id),
+            created_at: row.created_at,
+            username: info?.username || null,
+            display_name: info?.display_name || null,
+            avatar_url: info?.avatar_url || null
+        };
+    }));
+
+    return successResponse({ blocked });
+}
+
+// POST /api/trades/blocks - block a user { user_id }
+async function handlePost(request, env, user) {
+    if (!user || !isAuthorized(user)) {
+        return errorResponse('Unauthorized', 401);
+    }
+
+    const data = await request.json();
+    const error = validateFields(data, ['user_id']);
+    if (error) {
+        return errorResponse(error);
+    }
+
+    const blockedId = normalizeUserId(data.user_id);
+    if (isSameUser(blockedId, user.user_id)) {
+        return errorResponse('You cannot block yourself', 400);
+    }
+
+    // Idempotent: the UNIQUE index makes a repeat block a no-op.
+    await env.DBA.prepare(
+        'INSERT OR IGNORE INTO trade_blocks (blocker_id, blocked_id, created_at) VALUES (?, ?, ?)'
+    ).bind(normalizeUserId(user.user_id), blockedId, Date.now()).run();
+
+    return successResponse({ message: 'User blocked', user_id: blockedId }, 201);
+}
+
+// DELETE /api/trades/blocks/:userId - unblock a user
+async function handleDelete(env, path, user) {
+    if (!user || !isAuthorized(user)) {
+        return errorResponse('Unauthorized', 401);
+    }
+
+    const blockedId = normalizeUserId(path.split('/')[0]);
+    if (!blockedId) {
+        return errorResponse('User ID required', 400);
+    }
+
+    await env.DBA.prepare(
+        'DELETE FROM trade_blocks WHERE blocker_id IN (?, ?) AND blocked_id IN (?, ?)'
+    ).bind(...userIdForms(user.user_id), ...userIdForms(blockedId)).run();
+
+    return successResponse({ message: 'User unblocked', user_id: blockedId });
+}
+
+export async function onRequest(context) {
+    const { request, env } = context;
+    const url = new URL(request.url);
+    const prefix = '/api/trades/blocks';
+    const path = url.pathname.startsWith(prefix)
+        ? url.pathname.slice(prefix.length).replace(/^\//, '')
+        : '';
+
+    const corsHeaders = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    };
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { headers: corsHeaders });
+    }
+
+    try {
+        const user = await authenticateUser(request, env);
+
+        let response;
+        switch (request.method) {
+            case 'GET':
+                response = await handleGet(env, user);
+                break;
+            case 'POST':
+                response = await handlePost(request, env, user);
+                break;
+            case 'DELETE':
+                response = await handleDelete(env, path, user);
+                break;
+            default:
+                response = errorResponse('Method not allowed', 405);
+        }
+
+        const headers = new Headers(response.headers);
+        Object.entries(corsHeaders).forEach(([key, value]) => headers.set(key, value));
+        return new Response(response.body, { status: response.status, headers });
+    } catch (error) {
+        console.error('Trade blocks error:', error);
+        return new Response(JSON.stringify({ error: 'Internal server error' }), {
+            status: 500,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+    }
+}

--- a/functions/api/trades/listings/[[path]].js
+++ b/functions/api/trades/listings/[[path]].js
@@ -1,6 +1,8 @@
 import {
     authenticateUser,
     isAuthorized,
+    isModerator,
+    isTradeBanned,
     errorResponse,
     successResponse,
     validateFields,
@@ -29,13 +31,15 @@ function userHasThemeRole(user) {
 }
 
 // Handle GET requests
-async function handleGet(request, env, path) {
+async function handleGet(request, env, path, user) {
     const url = new URL(request.url);
+    // The signed-in viewer, used to flag which listings they've already liked.
+    const viewerId = user ? normalizeUserId(user.user_id) : null;
 
     // GET /api/trades/listings - List all active listings
     if (!path || path === '') {
         const { limit, offset } = parsePagination(url);
-        const { sortBy, sortOrder } = parseSort(url, ['created_at', 'updated_at', 'views'], 'created_at', 'DESC');
+        const { sortBy, sortOrder } = parseSort(url, ['created_at', 'updated_at', 'likes'], 'created_at', 'DESC');
 
         const params = url.searchParams;
         const category = params.get('category');
@@ -76,6 +80,8 @@ async function handleGet(request, env, path) {
             whereBindings.push(term, term, term, term);
         }
 
+        // like_count is aggregated from trade_likes; `liked` flags whether the
+        // signed-in viewer has liked each listing (0 for logged-out visitors).
         let query = `
             SELECT
                 tl.*,
@@ -84,13 +90,18 @@ async function handleGet(request, env, path) {
                 u.display_name AS u_display_name,
                 u.avatar_url AS u_avatar_url,
                 uts.average_rating AS u_average_rating,
-                uts.total_trades AS u_total_trades
+                uts.total_trades AS u_total_trades,
+                (SELECT COUNT(*) FROM trade_likes lk WHERE lk.listing_id = tl.id) AS like_count,
+                (SELECT COUNT(*) FROM trade_likes lk WHERE lk.listing_id = tl.id AND lk.user_id IN (?, ?)) AS liked
             FROM trade_listings tl
             LEFT JOIN users u ON u.user_id = tl.user_id
             LEFT JOIN user_trade_stats uts ON uts.user_id = tl.user_id
         `;
-        query += where + ` ORDER BY tl.${sortBy} ${sortOrder} LIMIT ? OFFSET ?`;
-        const bindings = [...whereBindings, limit, offset];
+        // 'likes' sorts by the aggregated count; the rest are real columns.
+        const orderBy = sortBy === 'likes' ? 'like_count' : `tl.${sortBy}`;
+        query += where + ` ORDER BY ${orderBy} ${sortOrder} LIMIT ? OFFSET ?`;
+        const likeBindings = viewerId ? userIdForms(viewerId) : ['\0', '\0'];
+        const bindings = [...likeBindings, ...whereBindings, limit, offset];
 
         const [{ results }, countRow] = await Promise.all([
             env.DBA.prepare(query).bind(...bindings).all(),
@@ -103,6 +114,7 @@ async function handleGet(request, env, path) {
                 u_user_id, u_username, u_display_name, u_avatar_url,
                 u_average_rating, u_total_trades,
                 offering_items, seeking_items,
+                like_count, liked, views,
                 ...listing
             } = row;
 
@@ -111,6 +123,8 @@ async function handleGet(request, env, path) {
                 user_id: normalizeUserId(listing.user_id),
                 offering_items: safeJsonParse(offering_items),
                 seeking_items: seeking_items ? safeJsonParse(seeking_items, null) : null,
+                like_count: like_count || 0,
+                liked: !!liked,
                 user: {
                     user_id: normalizeUserId(u_user_id),
                     username: u_username,
@@ -136,34 +150,38 @@ async function handleGet(request, env, path) {
             return errorResponse('Listing not found', 404);
         }
 
-        // Increment view count
-        await env.DBA.prepare(
-            'UPDATE trade_listings SET views = views + 1 WHERE id = ?'
-        ).bind(listingId).run();
-
         // Get user info
-        const user = await getUserWithStats(env, listing.user_id);
+        const owner = await getUserWithStats(env, listing.user_id);
 
-        // Get offer count
-        const offerCount = await env.DBA.prepare(
-            'SELECT COUNT(*) as count FROM trade_offers WHERE listing_id = ?'
-        ).bind(listingId).first();
+        // Get offer count + like count, and whether the viewer has liked it.
+        const [offerCount, likeCount, likedRow] = await Promise.all([
+            env.DBA.prepare('SELECT COUNT(*) as count FROM trade_offers WHERE listing_id = ?')
+                .bind(listingId).first(),
+            env.DBA.prepare('SELECT COUNT(*) as count FROM trade_likes WHERE listing_id = ?')
+                .bind(listingId).first(),
+            viewerId
+                ? env.DBA.prepare('SELECT id FROM trade_likes WHERE listing_id = ? AND user_id IN (?, ?)')
+                    .bind(listingId, ...userIdForms(viewerId)).first()
+                : Promise.resolve(null)
+        ]);
 
+        const { views, ...listingRest } = listing;
         return successResponse({
-            ...listing,
+            ...listingRest,
             user_id: normalizeUserId(listing.user_id),
             offering_items: safeJsonParse(listing.offering_items),
             seeking_items: listing.seeking_items ? safeJsonParse(listing.seeking_items, null) : null,
-            views: listing.views + 1,
             offer_count: offerCount.count,
+            like_count: likeCount.count,
+            liked: !!likedRow,
             user: {
-                user_id: user.user_id,
-                username: user.username,
-                display_name: user.display_name,
-                avatar_url: user.avatar_url,
-                average_rating: user.average_rating || 0,
-                total_trades: user.total_trades || 0,
-                total_reviews: user.total_reviews || 0
+                user_id: owner.user_id,
+                username: owner.username,
+                display_name: owner.display_name,
+                avatar_url: owner.avatar_url,
+                average_rating: owner.average_rating || 0,
+                total_trades: owner.total_trades || 0,
+                total_reviews: owner.total_reviews || 0
             }
         });
     }
@@ -171,10 +189,60 @@ async function handleGet(request, env, path) {
     return errorResponse('Invalid request', 400);
 }
 
+// Toggle the signed-in user's like on a listing. Returns the new like count
+// and whether the user now likes it.
+async function handleLikeToggle(env, listingId, user) {
+    if (!listingId) {
+        return errorResponse('Listing ID required', 400);
+    }
+
+    const listing = await env.DBA.prepare(
+        'SELECT id FROM trade_listings WHERE id = ?'
+    ).bind(listingId).first();
+    if (!listing) {
+        return errorResponse('Listing not found', 404);
+    }
+
+    const userId = normalizeUserId(user.user_id);
+    const existing = await env.DBA.prepare(
+        'SELECT id FROM trade_likes WHERE listing_id = ? AND user_id IN (?, ?)'
+    ).bind(listingId, ...userIdForms(userId)).first();
+
+    let liked;
+    if (existing) {
+        await env.DBA.prepare('DELETE FROM trade_likes WHERE id = ?').bind(existing.id).run();
+        liked = false;
+    } else {
+        await env.DBA.prepare(
+            'INSERT INTO trade_likes (listing_id, user_id, created_at) VALUES (?, ?, ?)'
+        ).bind(listingId, userId, Date.now()).run();
+        liked = true;
+    }
+
+    const { count } = await env.DBA.prepare(
+        'SELECT COUNT(*) as count FROM trade_likes WHERE listing_id = ?'
+    ).bind(listingId).first();
+
+    return successResponse({ liked, like_count: count });
+}
+
 // Handle POST requests
 async function handlePost(request, env, path, user) {
     if (!user || !isAuthorized(user)) {
         return errorResponse('Unauthorized', 401);
+    }
+
+    // POST /api/trades/listings/:id/like - toggle a like on a listing
+    {
+        const parts = path.split('/');
+        if (parts[1] === 'like') {
+            return handleLikeToggle(env, parts[0], user);
+        }
+    }
+
+    // Banned players cannot create listings.
+    if (await isTradeBanned(env, user.user_id)) {
+        return errorResponse('You are banned from trading', 403);
     }
 
     // POST /api/trades/listings - Create new listing
@@ -404,8 +472,22 @@ async function handleDelete(request, env, path, user) {
         return errorResponse('Listing not found', 404);
     }
 
-    if (!isSameUser(listing.user_id, user.user_id)) {
+    const owner = isSameUser(listing.user_id, user.user_id);
+    const mod = isModerator(user);
+    if (!owner && !mod) {
         return errorResponse('You can only delete your own listings', 403);
+    }
+
+    // Moderators hard-delete the listing (and its dependent rows) so it is
+    // removed outright; owners keep the existing soft-delete (cancelled) so
+    // their trade history is preserved.
+    if (mod && !owner) {
+        await env.DBA.batch([
+            env.DBA.prepare('DELETE FROM trade_likes WHERE listing_id = ?').bind(listingId),
+            env.DBA.prepare('DELETE FROM trade_offers WHERE listing_id = ?').bind(listingId),
+            env.DBA.prepare('DELETE FROM trade_listings WHERE id = ?').bind(listingId)
+        ]);
+        return successResponse({ message: 'Listing removed by moderator' });
     }
 
     // Soft delete by setting status to cancelled
@@ -438,15 +520,14 @@ export async function onRequest(context) {
     }
 
     try {
-        let user = null;
-        if (request.method !== 'GET') {
-            user = await authenticateUser(request, env);
-        }
+        // Authenticate on every method: GET stays public, but a token (when
+        // present) lets the response flag which listings the viewer has liked.
+        const user = await authenticateUser(request, env);
 
         let response;
         switch (request.method) {
             case 'GET':
-                response = await handleGet(request, env, path);
+                response = await handleGet(request, env, path, user);
                 break;
             case 'POST':
                 response = await handlePost(request, env, path, user);

--- a/functions/api/trades/messages/[[path]].js
+++ b/functions/api/trades/messages/[[path]].js
@@ -1,6 +1,8 @@
 import {
     authenticateUser,
     isAuthorized,
+    isTradeBanned,
+    isBlockedBy,
     errorResponse,
     successResponse,
     validateFields,
@@ -188,6 +190,16 @@ async function handlePost(request, env, path, user) {
 
         if (!recipient) {
             return errorResponse('Recipient not found', 404);
+        }
+
+        // Banned players cannot send messages.
+        if (await isTradeBanned(env, user.user_id)) {
+            return errorResponse('You are banned from trading', 403);
+        }
+
+        // The recipient may have blocked this user.
+        if (await isBlockedBy(env, to_user_id, user.user_id)) {
+            return errorResponse('You cannot message this user', 403);
         }
 
         // If listing_id is provided, verify the users are involved in the listing

--- a/functions/api/trades/offers/[[path]].js
+++ b/functions/api/trades/offers/[[path]].js
@@ -1,6 +1,8 @@
 import {
     authenticateUser,
     isAuthorized,
+    isTradeBanned,
+    isBlockedBy,
     errorResponse,
     successResponse,
     validateFields,
@@ -157,6 +159,16 @@ async function handlePost(request, env, path, user) {
         // Can't make offer on own listing
         if (isSameUser(listing.user_id, user.user_id)) {
             return errorResponse('Cannot make offer on your own listing', 400);
+        }
+
+        // Banned players cannot make offers.
+        if (await isTradeBanned(env, user.user_id)) {
+            return errorResponse('You are banned from trading', 403);
+        }
+
+        // The listing owner may have blocked this user to stop their offers.
+        if (await isBlockedBy(env, listing.user_id, user.user_id)) {
+            return errorResponse('You cannot make an offer on this listing', 403);
         }
 
         // Validate offered_items is an array

--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -641,9 +641,38 @@ class Auth extends EventTarget {
         return `/api/roblox-proxy?mode=cdn-asset&hash=${hash}`;
     }
 
+    // Tear down a model previously rendered into `container` (cancel its RAF
+    // loop, stop observing it, drop the WebGL context and remove the canvas) so
+    // the same container can be re-rendered without leaking a context.
+    _disposeContainerModel(container) {
+        const model = container && container._model3D;
+        if (!model) return;
+        if (model.animationId) cancelAnimationFrame(model.animationId);
+        model.observer?.disconnect();
+        try { model.renderer?.dispose(); } catch (e) { /* ignore */ }
+        if (model.renderer?.domElement?.parentNode === container) {
+            container.removeChild(model.renderer.domElement);
+        }
+        container._model3D = null;
+        if (this._model3D === model) this._model3D = null;
+    }
+
+    // Render a spinning 3D Roblox avatar for `userId` into `container`.
+    // State is tracked per-container (on the element itself) rather than on a
+    // single shared instance field, so the auth modal and the profile page can
+    // each host their own model at the same time without clobbering one another.
     async render3DPlayerModel(userId, container) {
-        if (this._rendering3DModel) return;
-        this._rendering3DModel = true;
+        if (!userId || !container) {
+            console.error('Invalid userId or container:', userId, container);
+            if (container) container.style.display = 'none';
+            return;
+        }
+
+        // A render is already in flight (or done) for this container — don't
+        // start a second one on top of it.
+        if (container._model3DLoading) return;
+        container._model3DLoading = true;
+        this._disposeContainerModel(container);
         container.className = 'loadin';
 
         // Wait for Three.js to load
@@ -651,13 +680,7 @@ class Auth extends EventTarget {
         if (typeof THREE === 'undefined') {
             console.error('Three.js failed to load');
             container.style.display = '';
-            this._rendering3DModel = false;
-            return;
-        }
-
-        if (!userId || !container) {
-            console.error('Invalid userId or container:', userId, container);
-            if (container) container.style.display = 'none';
+            container._model3DLoading = false;
             return;
         }
 
@@ -666,7 +689,7 @@ class Auth extends EventTarget {
             if (!response.ok) {
                 console.error('Failed to load 3D model:', response.status);
                 container.style.display = '';
-                this._rendering3DModel = false;
+                container._model3DLoading = false;
                 return;
             }
             const metadata = await response.json();
@@ -759,8 +782,9 @@ class Auth extends EventTarget {
                 objLoader.load(this.getCdnUrl(objUrl), (object) => {
                     scene.add(object);
 
-                    // Store references for later animations
-                    this._model3D = {
+                    // Store references for later animations — on the container
+                    // itself so each container animates independently.
+                    const model = {
                         scene,
                         camera,
                         renderer,
@@ -769,30 +793,38 @@ class Auth extends EventTarget {
                         isVisible: true,
                         rotationSpeed: 0.01,
                         initialCameraPosition: { ...camera.position },
-                        aabb: aabb
+                        aabb: aabb,
+                        observer: null
                     };
+                    container._model3D = model;
+                    // The epic post-login animation only ever targets the auth
+                    // modal's container, so expose that one as this._model3D.
+                    if (container.id === 'player-model-container') {
+                        this._model3D = model;
+                    }
 
                     // Animation loop with visibility control
                     const animateModel = () => {
-                        if (!this._model3D.isVisible) return;
-                        this._model3D.object.rotation.y += this._model3D.rotationSpeed;
-                        this._model3D.renderer.render(this._model3D.scene, this._model3D.camera);
-                        this._model3D.animationId = requestAnimationFrame(animateModel);
+                        if (!model.isVisible) return;
+                        model.object.rotation.y += model.rotationSpeed;
+                        model.renderer.render(model.scene, model.camera);
+                        model.animationId = requestAnimationFrame(animateModel);
                     };
 
                     // Use Intersection Observer to pause animation when not visible
                     const observer = new IntersectionObserver((entries) => {
                         entries.forEach(entry => {
-                            this._model3D.isVisible = entry.isIntersecting;
-                            if (this._model3D.isVisible && !this._model3D.animationId) {
+                            model.isVisible = entry.isIntersecting;
+                            if (model.isVisible && !model.animationId) {
                                 animateModel();
-                            } else if (!this._model3D.isVisible && this._model3D.animationId) {
-                                cancelAnimationFrame(this._model3D.animationId);
-                                this._model3D.animationId = null;
+                            } else if (!model.isVisible && model.animationId) {
+                                cancelAnimationFrame(model.animationId);
+                                model.animationId = null;
                             }
                         });
                     }, { threshold: 0.1 });
 
+                    model.observer = observer;
                     observer.observe(container);
 
                     // Start animation
@@ -801,14 +833,14 @@ class Auth extends EventTarget {
                     // Show model immediately when loaded
                     container.className = 'active';
                     container.style.display = '';
-                    this._rendering3DModel = false;
+                    container._model3DLoading = false;
                 });
             });
         } catch (error) {
             console.error('Error rendering 3D model:', error);
             container.className = 'active';
             container.style.display = '';
-            this._rendering3DModel = false;
+            container._model3DLoading = false;
         }
     }
 

--- a/js/trading.js
+++ b/js/trading.js
@@ -240,7 +240,8 @@ class TradingHub {
             seeking_items: listing.seeking_items || [],
             created_at: listing.created_at,
             updated_at: listing.updated_at,
-            views: listing.views || 0,
+            like_count: listing.like_count || 0,
+            liked: !!listing.liked,
             user: listing.user
         };
     }
@@ -290,7 +291,8 @@ class TradingHub {
         await Promise.all([
             this.loadMyListings(),
             this.loadMyOffers(),
-            this.loadCompletedTrades()
+            this.loadCompletedTrades(),
+            this.loadBlocked()
         ]);
         this.updateMyTradesBadge();
     }
@@ -319,7 +321,8 @@ class TradingHub {
                 offering_items: listing.offering_items || [],
                 seeking_items: listing.seeking_items || [],
                 created_at: listing.created_at,
-                views: listing.views || 0,
+                like_count: listing.like_count || 0,
+                liked: !!listing.liked,
                 user: listing.user
             }));
         } catch (error) {
@@ -922,6 +925,12 @@ class TradingHub {
             label: 'Biggest Trade',
             // descending bars
             svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16M4 12h10M4 18h5"/></svg>'
+        },
+        {
+            value: 'liked',
+            label: 'Most Liked',
+            // heart
+            svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg>'
         }
     ];
 
@@ -1026,6 +1035,12 @@ class TradingHub {
             // Most items first, then newest.
             filtered.sort((a, b) =>
                 (this.tradeSize(b) - this.tradeSize(a)) ||
+                (b.created_at - a.created_at)
+            );
+        } else if (this.filters.sort === 'liked') {
+            // Most liked first, then newest.
+            filtered.sort((a, b) =>
+                ((b.like_count || 0) - (a.like_count || 0)) ||
                 (b.created_at - a.created_at)
             );
         } else {
@@ -1135,13 +1150,174 @@ class TradingHub {
             ${trade.description ? `<div class="trade-card-description">${this.esc(trade.description)}</div>` : ''}
             <div class="trade-card-actions">
                 <button class="btn-view-trade" data-id="${trade.id}">View Details</button>
+                ${this.likeButtonHTML(trade)}
+                ${this.isModerator() ? `<button class="btn-mod-delete" title="Remove listing (moderator)" data-id="${trade.id}">Remove</button>` : ''}
             </div>
         `;
 
         // Event listeners — Make Offer lives inside the detail view now.
         card.querySelector('.btn-view-trade')?.addEventListener('click', () => this.viewTrade(trade.id));
+        card.querySelector('.btn-like')?.addEventListener('click', (e) => this.toggleLike(trade.id, e.currentTarget));
+        card.querySelector('.btn-mod-delete')?.addEventListener('click', () => this.modDeleteListing(trade.id));
 
         return card;
+    }
+
+    // Heart button showing the current like count and the viewer's like state.
+    likeButtonHTML(trade) {
+        const liked = !!trade.liked;
+        const count = trade.like_count || 0;
+        return `
+            <button class="btn-like${liked ? ' liked' : ''}" data-id="${trade.id}" aria-pressed="${liked}" title="${liked ? 'Unlike' : 'Like'} this trade">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="${liked ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+                <span class="like-count">${count}</span>
+            </button>`;
+    }
+
+    // Toggle the signed-in user's like on a listing and update the button in place.
+    async toggleLike(listingId, btnEl) {
+        if (!this.currentUser) {
+            this.showToast('Please sign in to like trades', 'warning');
+            return;
+        }
+        try {
+            const response = await fetch(`${this.apiBase}/listings/${listingId}/like`, {
+                method: 'POST',
+                headers: this.authHeaders({ 'Content-Type': 'application/json' })
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `Failed to like (${response.status})`);
+            }
+            const { liked, like_count } = await response.json();
+
+            // Keep the in-memory trade objects in sync so re-renders don't revert.
+            [this.trades, this.myTrades].forEach(list => {
+                const t = list.find(x => x.id === listingId);
+                if (t) { t.liked = liked; t.like_count = like_count; }
+            });
+
+            if (btnEl) {
+                btnEl.classList.toggle('liked', liked);
+                btnEl.setAttribute('aria-pressed', String(liked));
+                const svg = btnEl.querySelector('svg');
+                if (svg) svg.setAttribute('fill', liked ? 'currentColor' : 'none');
+                const countEl = btnEl.querySelector('.like-count');
+                if (countEl) countEl.textContent = like_count;
+            }
+            // Refresh the detail modal's like button if it's showing this trade.
+            const detailBtn = document.querySelector(`#tradeDetailBody .btn-like[data-id="${listingId}"]`);
+            if (detailBtn && detailBtn !== btnEl) {
+                detailBtn.classList.toggle('liked', liked);
+                detailBtn.querySelector('svg')?.setAttribute('fill', liked ? 'currentColor' : 'none');
+                const c = detailBtn.querySelector('.like-count');
+                if (c) c.textContent = like_count;
+            }
+        } catch (error) {
+            console.error('Failed to toggle like:', error);
+            this.showToast(error.message || 'Failed to like trade', 'error');
+        }
+    }
+
+    // Moderator action: remove any listing outright.
+    async modDeleteListing(listingId) {
+        if (!this.isModerator()) return;
+        if (!confirm('Remove this listing as a moderator? This permanently deletes it and its offers.')) return;
+        try {
+            const response = await fetch(`${this.apiBase}/listings/${listingId}`, {
+                method: 'DELETE',
+                headers: this.authHeaders({ 'Content-Type': 'application/json' })
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `Failed to remove listing (${response.status})`);
+            }
+            this.showToast('Listing removed', 'success');
+            this.closeDetailModal();
+            this.trades = this.trades.filter(t => t.id !== listingId);
+            await this.loadTrades(this.browsePage);
+            this.renderTrades();
+        } catch (error) {
+            console.error('Failed to remove listing:', error);
+            this.showToast(error.message || 'Failed to remove listing', 'error');
+        }
+    }
+
+    // Block a user so they can no longer send you offers or messages.
+    async blockUser(userId, name) {
+        if (!this.currentUser) {
+            this.showToast('Please sign in first', 'warning');
+            return;
+        }
+        if (!confirm(`Block ${name || 'this user'}? They will no longer be able to send you offers or messages.`)) return;
+        try {
+            const response = await fetch(`${this.apiBase}/blocks`, {
+                method: 'POST',
+                headers: this.authHeaders({ 'Content-Type': 'application/json' }),
+                body: JSON.stringify({ user_id: userId })
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `Failed to block (${response.status})`);
+            }
+            this.showToast('User blocked', 'success');
+        } catch (error) {
+            console.error('Failed to block user:', error);
+            this.showToast(error.message || 'Failed to block user', 'error');
+        }
+    }
+
+    async unblockUser(userId) {
+        try {
+            const response = await fetch(`${this.apiBase}/blocks/${encodeURIComponent(userId)}`, {
+                method: 'DELETE',
+                headers: this.authHeaders({ 'Content-Type': 'application/json' })
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `Failed to unblock (${response.status})`);
+            }
+            this.showToast('User unblocked', 'success');
+            await this.loadBlocked();
+            if (this.activeMyTab === 'blocked') this.renderMyTrades();
+        } catch (error) {
+            console.error('Failed to unblock user:', error);
+            this.showToast(error.message || 'Failed to unblock user', 'error');
+        }
+    }
+
+    // Moderator action: ban a player from the trading system.
+    async banUser(userId, name) {
+        if (!this.isModerator()) return;
+        const reason = prompt(`Ban ${name || 'this player'} from trading? Optionally enter a reason:`, '');
+        if (reason === null) return; // cancelled
+        try {
+            const response = await fetch(`${this.apiBase}/admin/ban`, {
+                method: 'POST',
+                headers: this.authHeaders({ 'Content-Type': 'application/json' }),
+                body: JSON.stringify({ user_id: userId, reason: reason || null })
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `Failed to ban (${response.status})`);
+            }
+            this.showToast(`${name || 'Player'} banned from trading`, 'success');
+        } catch (error) {
+            console.error('Failed to ban user:', error);
+            this.showToast(error.message || 'Failed to ban user', 'error');
+        }
+    }
+
+    async loadBlocked() {
+        if (!this.currentUser) { this.blockedUsers = []; return; }
+        try {
+            const response = await fetch(`${this.apiBase}/blocks`, { headers: this.authHeaders(), cache: 'no-store' });
+            if (!response.ok) return;
+            const data = await response.json();
+            this.blockedUsers = data.blocked || [];
+        } catch (error) {
+            console.error('Failed to load blocked users:', error);
+        }
     }
 
     // A single cursor-following tooltip, shared by every trade item thumbnail,
@@ -1249,7 +1425,38 @@ class TradingHub {
             this.renderOffersList(feed, this.sentOffers, false);
         } else if (this.activeMyTab === 'history') {
             this.renderHistoryList(feed);
+        } else if (this.activeMyTab === 'blocked') {
+            this.renderBlockedList(feed);
         }
+    }
+
+    renderBlockedList(feed) {
+        const blocked = this.blockedUsers || [];
+        if (blocked.length === 0) {
+            feed.innerHTML = this.emptyState('No blocked users', 'Blocked users can\'t send you offers or messages. Block someone from a trade or message.');
+            return;
+        }
+        feed.innerHTML = '';
+        blocked.forEach(u => {
+            const card = document.createElement('div');
+            card.className = 'offer-card blocked-card';
+            const name = u.username || u.display_name || `User ${u.user_id}`;
+            card.innerHTML = `
+                <div class="offer-card-header">
+                    <div class="offer-card-info" style="display:flex;align-items:center;gap:10px">
+                        <img class="conv-avatar" src="${u.avatar_url || './imgs/placeholder.png'}" alt="${this.esc(name)}" onerror="this.src='./imgs/placeholder.png'">
+                        <div class="offer-card-title">${this.esc(name)}</div>
+                    </div>
+                </div>
+                <div class="offer-card-actions"></div>
+            `;
+            const unblockBtn = document.createElement('button');
+            unblockBtn.className = 'btn-secondary';
+            unblockBtn.textContent = 'Unblock';
+            unblockBtn.addEventListener('click', () => this.unblockUser(u.user_id));
+            card.querySelector('.offer-card-actions').appendChild(unblockBtn);
+            feed.appendChild(card);
+        });
     }
 
     emptyState(title, message) {
@@ -1354,6 +1561,15 @@ class TradingHub {
             msgBtn.textContent = 'Message';
             msgBtn.addEventListener('click', () => this.openThreadWith(party.user_id, partyName, offer.listing_id, offer.id));
             actions.appendChild(msgBtn);
+        }
+
+        // Received an unwanted offer? Block the sender so they can't send more.
+        if (isReceived && party?.user_id) {
+            const blockBtn = document.createElement('button');
+            blockBtn.className = 'btn-danger';
+            blockBtn.textContent = 'Block';
+            blockBtn.addEventListener('click', () => this.blockUser(party.user_id, partyName));
+            actions.appendChild(blockBtn);
         }
 
         if (actions.children.length === 0) actions.remove();
@@ -1514,7 +1730,7 @@ class TradingHub {
                 </div>
                 <div class="detail-meta">
                     <span>Posted ${timeAgo}</span>
-                    <span>${trade.views || 0} views</span>
+                    ${this.likeButtonHTML(trade)}
                     <span class="trade-status-badge ${trade.status}">${trade.status}</span>
                 </div>
                 <div class="detail-reviews" id="detailReviews"></div>
@@ -1523,6 +1739,11 @@ class TradingHub {
             <div class="detail-actions">
                 ${trade.status === 'active' ? `<button class="btn-make-offer" style="flex:1" data-id="${trade.id}">Make Offer</button>` : ''}
                 <button class="btn-secondary btn-message-trader">Message Trader</button>
+                <button class="btn-secondary btn-block-trader">Block</button>
+                ${this.isModerator() ? `
+                    <button class="btn-danger btn-mod-delete">Remove</button>
+                    <button class="btn-danger btn-mod-ban">Ban</button>
+                ` : ''}
             </div>` : ''}
         `;
 
@@ -1534,6 +1755,12 @@ class TradingHub {
             this.closeDetailModal();
             this.openThreadWith(trade.user_id, trade.user?.username || 'Trader', trade.id, null);
         });
+        body.querySelector('.btn-like')?.addEventListener('click', (e) => this.toggleLike(trade.id, e.currentTarget));
+        body.querySelector('.btn-block-trader')?.addEventListener('click', () => {
+            this.blockUser(trade.user_id, trade.user?.username);
+        });
+        body.querySelector('.btn-mod-delete')?.addEventListener('click', () => this.modDeleteListing(trade.id));
+        body.querySelector('.btn-mod-ban')?.addEventListener('click', () => this.banUser(trade.user_id, trade.user?.username));
 
         modal.classList.add('active');
 
@@ -1880,16 +2107,29 @@ class TradingHub {
     // Roles that unlock card themes. Everyone else gets 'default' only.
     static THEME_ROLES = ['donator', 'vip', 'moderator', 'mod', 'admin'];
 
-    // Does the signed-in user have a role that unlocks card themes?
-    canUseThemes() {
+    // Roles that can moderate the trading system (delete any listing, ban).
+    static MODERATOR_ROLES = ['admin', 'owner', 'moderator', 'mod'];
+
+    // Signed-in user's roles as a lowercased string array.
+    userRoles() {
         const raw = this.currentUser?.role ?? this.currentUser?.roles;
-        if (!raw) return false;
+        if (!raw) return [];
         let roles = raw;
         if (typeof roles === 'string') {
             try { roles = JSON.parse(roles); } catch { roles = [roles]; }
         }
-        if (!Array.isArray(roles)) return false;
-        return roles.some(r => TradingHub.THEME_ROLES.includes(String(r).toLowerCase()));
+        if (!Array.isArray(roles)) return [];
+        return roles.map(r => String(r).toLowerCase());
+    }
+
+    // Does the signed-in user have a role that unlocks card themes?
+    canUseThemes() {
+        return this.userRoles().some(r => TradingHub.THEME_ROLES.includes(r));
+    }
+
+    // Is the signed-in user an admin/moderator?
+    isModerator() {
+        return this.userRoles().some(r => TradingHub.MODERATOR_ROLES.includes(r));
     }
 
     // Lock the non-default theme buttons for users without a donator role, and
@@ -2136,7 +2376,18 @@ class TradingHub {
 
         if (empty) empty.style.display = 'none';
         active.style.display = '';
-        if (header) header.textContent = this.activeThread.name;
+        // Rebuild the header (name + Block action) only when the active thread
+        // changes, so background polls don't restack listeners.
+        if (header && header.dataset.userId !== String(this.activeThread.userId)) {
+            header.dataset.userId = String(this.activeThread.userId);
+            header.innerHTML = `
+                <span class="thread-header-name">${this.esc(this.activeThread.name)}</span>
+                <button class="thread-header-block btn-danger" type="button" title="Block this user">Block</button>
+            `;
+            header.querySelector('.thread-header-block')?.addEventListener('click', () => {
+                this.blockUser(this.activeThread.userId, this.activeThread.name);
+            });
+        }
         if (!silent) messagesEl.innerHTML = '<div class="thread-loading">Loading…</div>';
 
         try {

--- a/migrations/027_trade_blocks_bans_likes.sql
+++ b/migrations/027_trade_blocks_bans_likes.sql
@@ -1,0 +1,47 @@
+-- Trading moderation + social features
+--
+-- Adds three tables backing the new trading features:
+--   * trade_blocks  — a user blocks another so they stop receiving offers/messages
+--   * trade_bans    — admins/mods ban a player from using the trading system
+--   * trade_likes   — likes on trade listings (replaces the old view counter)
+--
+-- Idempotent (IF NOT EXISTS) so it is safe to run whether or not the tables
+-- were previously created. Ids are stored as TEXT to match the other trade
+-- tables (see migrations/026 for the id-normalization context).
+
+-- ===== Tables =====
+
+-- One row per (blocker, blocked) pair. The blocker no longer receives offers
+-- or direct messages from the blocked user.
+CREATE TABLE IF NOT EXISTS trade_blocks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    blocker_id TEXT NOT NULL,                   -- the user doing the blocking
+    blocked_id TEXT NOT NULL,                   -- the user being blocked
+    created_at INTEGER NOT NULL
+);
+
+-- Players banned from trading by an admin/mod. Presence of a row = banned.
+CREATE TABLE IF NOT EXISTS trade_bans (
+    user_id TEXT PRIMARY KEY,                   -- the banned player
+    banned_by TEXT NOT NULL,                    -- admin/mod who issued the ban
+    reason TEXT,
+    created_at INTEGER NOT NULL
+);
+
+-- One row per (listing, user) like. The listing's like count is COUNT(*) over
+-- this table; a user has liked a listing when their row exists.
+CREATE TABLE IF NOT EXISTS trade_likes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    listing_id INTEGER NOT NULL,
+    user_id TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+-- ===== Indexes =====
+CREATE INDEX IF NOT EXISTS idx_trade_blocks_blocker ON trade_blocks(blocker_id);
+CREATE INDEX IF NOT EXISTS idx_trade_likes_listing ON trade_likes(listing_id);
+
+-- One block per (blocker, blocked) and one like per (listing, user). Kept last
+-- so a failure on pre-existing duplicate rows cannot block table creation.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_blocks_unique ON trade_blocks(blocker_id, blocked_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_likes_unique ON trade_likes(listing_id, user_id);

--- a/trading.html
+++ b/trading.html
@@ -134,6 +134,7 @@
                         <button class="my-tab" data-mytab="received">Received Offers</button>
                         <button class="my-tab" data-mytab="sent">Sent Offers</button>
                         <button class="my-tab" data-mytab="history">History</button>
+                        <button class="my-tab" data-mytab="blocked">Blocked</button>
                     </div>
                 </div>
                 <div class="my-trades-feed" id="myTradesFeed">


### PR DESCRIPTION
## Summary
This PR adds social features (likes), user safety controls (blocks), and moderation tools (bans) to the trading system, replacing the view counter with a like-based engagement metric.

## Key Changes

**Likes System**
- Replace view counter with `like_count` and `liked` fields on listings
- Add `POST /api/trades/listings/:id/like` endpoint to toggle likes
- Add "Most Liked" sort option in the browse UI
- Display heart icon button with like count on trade cards and detail view
- Like state is tracked per user and persists across sessions

**User Blocks**
- Add `POST /api/trades/blocks` to block a user (prevents them from sending offers/messages)
- Add `GET /api/trades/blocks` to list blocked users
- Add `DELETE /api/trades/blocks/:userId` to unblock
- Add "Blocked" tab in My Trades showing blocked users with unblock button
- Enforce blocks when creating offers and sending messages

**Moderation & Bans**
- Add `POST /api/trades/admin/ban` to ban players from trading (admin/mod only)
- Add `GET /api/trades/admin/bans` to list banned players
- Add `DELETE /api/trades/admin/ban/:userId` to lift bans
- Add moderator "Remove" button on trade cards to hard-delete listings
- Prevent banned users from creating listings, making offers, or sending messages
- Add role-based access control: `admin`, `owner`, `moderator`, `mod` can moderate

**Database**
- Add `trade_likes` table (listing_id, user_id, created_at) with unique constraint
- Add `trade_blocks` table (blocker_id, blocked_id, created_at) with unique constraint
- Add `trade_bans` table (user_id, banned_by, reason, created_at)
- Create migration `027_trade_blocks_bans_likes.sql` with all three tables and indexes

**API Updates**
- Update listing responses to include `like_count` and `liked` instead of `views`
- Change sort parameter from `views` to `likes` for listing queries
- Add ban/block checks to offers and messages endpoints
- Add helper functions: `isModerator()`, `isTradeBanned()`, `isBlockedBy()`, `parseRoles()`

**UI/UX**
- Add heart icon button showing like count on each trade card
- Add "Most Liked" sort option in browse filters
- Add moderator delete button (red) on trade cards
- Add block/unblock buttons in message threads and blocked users list
- Add CSS styling for like button (filled when liked, hover effects)
- Add CSS styling for moderator delete button and blocked users list

**3D Model Rendering Fix**
- Fix memory leak in `render3DPlayerModel()` by tracking model state per-container instead of globally
- Add `_disposeContainerModel()` to properly clean up WebGL contexts and animation frames
- Allow multiple 3D models to render simultaneously (auth modal + profile page)

## Notable Implementation Details
- Likes are aggregated via `COUNT(*)` on the `trade_likes` table for performance
- The `liked` field is computed per-viewer using a subquery with `userIdForms()` normalization
- Blocks are directional: only the blocker is protected from the blocked user
- Moderators cannot ban other moderators/admins
- All moderation endpoints require authenticated user with moderator role
- Block/ban checks happen before offer/message creation to prevent abuse

https://claude.ai/code/session_015V5HPacnxpxx8cHzQ6R2B3