### PR TITLE
Add value tier system with "+" explanation and tier labels

### DIFF
--- a/css/modal.css
+++ b/css/modal.css
@@ -297,6 +297,30 @@ body:has(.item-modal.active) {
     transform: translateX(-50%) scale(1);
 }
 
+/* Tier "+" / Owner's Choice tooltip on the modal price — same tap-to-reveal
+   pattern as the tax indicator (click toggles .show-tooltip), so it works on
+   touch where hover doesn't exist. Desktop hover reveals it too. */
+.modal-price h2.has-tier-tooltip {
+    position: relative;
+    cursor: help;
+}
+
+.tier-tooltip {
+    white-space: normal;
+    width: max-content;
+    max-width: 220px;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.35;
+}
+
+.modal-price h2.has-tier-tooltip.show-tooltip .tier-tooltip,
+.modal-price h2.has-tier-tooltip:hover .tier-tooltip {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+}
+
 /* Demand Rating Styles */
 .modal-demand {
     width: 100%;

--- a/css/style.css
+++ b/css/style.css
@@ -901,6 +901,12 @@ main {
     color: var(--danger);
 }
 
+/* Tier-labelled price on cards: help cursor hints the native title tooltip
+   ("+" = typical average range / O/C = Owner's Choice). */
+.item-price.has-tier-tooltip {
+    cursor: help;
+}
+
 .unstable-mark {
     margin-left: 2px;
     font-weight: bold;

--- a/css/value-tiers.css
+++ b/css/value-tiers.css
@@ -1,0 +1,155 @@
+/* =============================================================================
+   value-tiers.css — styles for the tier legend/reference component rendered by
+   ValueTiers.renderTierLegend() (js/core/valueTiers.js) and the
+   "What does the + mean?" page (value-tiers.html).
+
+   Rides on the shared design tokens (css/tokens.css): glassy translucent
+   surfaces with soft inset clay shadows, matching the scammer/trading cards.
+   ========================================================================== */
+
+.tiers-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-5) var(--space-4) var(--space-8);
+    color: var(--text-1);
+}
+
+.tiers-page h1 {
+    font-family: var(--font-display);
+    font-size: var(--text-3xl);
+    text-align: center;
+    margin: var(--space-5) 0 var(--space-2);
+}
+
+.tiers-page .tiers-intro {
+    text-align: center;
+    color: var(--text-2);
+    font-size: var(--text-base);
+    line-height: 1.6;
+    margin: 0 auto var(--space-5);
+    max-width: 560px;
+}
+
+.tiers-page .tiers-intro strong {
+    color: var(--text-1);
+}
+
+/* Glassy clay card wrapping each section. */
+.tiers-card {
+    background: var(--bg-item);
+    border: 2px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    margin-bottom: var(--space-5);
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+    box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25), var(--shadow-2);
+}
+
+.tiers-card h2 {
+    font-size: var(--text-xl);
+    margin: 0 0 var(--space-3);
+}
+
+.tiers-card p {
+    color: var(--text-2);
+    line-height: 1.6;
+    margin: 0 0 var(--space-3);
+}
+
+.tiers-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* ── Legend table (renderTierLegend output) ── */
+.tier-legend-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-base);
+}
+
+.tier-legend-table th {
+    text-align: left;
+    color: var(--text-3);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0 var(--space-3) var(--space-2);
+    border-bottom: 1px solid var(--border-1);
+}
+
+.tier-legend-table td {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-1);
+}
+
+.tier-legend-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.tier-legend-table tbody tr {
+    transition: background var(--dur-1) var(--ease-out-quart);
+}
+
+.tier-legend-table tbody tr:hover {
+    background: var(--bg-item-hover);
+}
+
+.tier-range {
+    color: var(--text-2);
+    font-family: var(--font-num);
+}
+
+/* Tier chip — same pill language as the catalog's .item-price badge. */
+.tier-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: 1000 12px var(--font-num);
+    color: #ffffff;
+    background: linear-gradient(to top, #000000, #00000040);
+    outline: 1px solid #00000091;
+    border-radius: var(--radius-pill);
+    padding: 3px 9px;
+    white-space: nowrap;
+}
+
+.tier-chip::before {
+    content: '';
+    background: url('data:image/svg+xml,%3Csvg%20style%3D%22width%3A%2013px%3B%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2016.6%2018%22%3E%3Cpath%20d%3D%22M6.251%206.993v3.999h4.025V6.99Zm-.156-4.689c1.917-1.213%202.507-1.154%204.484.034l3.37%202.027c.648.43%201.255.949%201.157%202.077v4.444c.009%201.578-.127%202.032-1.065%202.656l-3.492%202.052c-2.118%201.195-2.219%201.353-4.55.001l-3.28-1.913c-.886-.562-1.373-1.115-1.315-2.45V6.733c-.025-1.63.458-1.874%201.242-2.405Zm.395%201.298c1.287-.804%201.855-1.088%203.612.034l2.777%201.641c.568.423.954.838.96%201.652v3.952c-.007.705-.271%201.405-.9%201.77l-2.813%201.684c-1.786.942-1.799%201.004-3.127.287l-3.22-1.835c-.658-.474-1.038-.651-1.006-2.009V7.131c.005-1.044.193-1.432.991-1.952ZM5.605.944C7.71-.331%208.871-.345%2011.011.985l4.062%202.444c.646.363%201.512%201.515%201.528%202.588v5.847c.003%201.055-.645%202.014-1.424%202.63l-4.178%202.501c-1.843%201.087-3.052%201.56-5.486.002l-3.928-2.348C.71%2014.043-.006%2013.267%200%2011.695V6.272c.033-1.551.668-2.233%201.498-2.899Z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E') no-repeat center center;
+    width: 12px;
+    height: 13px;
+    background-size: contain;
+}
+
+/* O/C chip: gold accent, no robux icon (it isn't a numeric value). */
+.tier-chip-oc {
+    color: var(--gold);
+    outline-color: var(--gold);
+}
+
+.tier-chip-oc::before {
+    display: none;
+}
+
+.tier-oc-row td {
+    border-top: 2px solid var(--border-2);
+}
+
+@media (max-width: 480px) {
+    .tiers-page {
+        padding-left: var(--space-3);
+        padding-right: var(--space-3);
+    }
+
+    .tiers-card {
+        padding: var(--space-4);
+    }
+
+    .tier-legend-table td,
+    .tier-legend-table th {
+        padding-left: var(--space-2);
+        padding-right: var(--space-2);
+    }
+}

--- a/js/components/item-card.js
+++ b/js/components/item-card.js
@@ -77,7 +77,7 @@ export function fitItemName(nameEl, name, baseSize = NAME_FIT_BASE_PX) {
  * @param {string}  [ctx.category]         item category (defaults item.category)
  */
 export function renderItemCard(item, ctx = {}) {
-    const { wishlist = [], favorites = [], convertPrice = (p) => p } = ctx;
+    const { wishlist = [], favorites = [], convertPrice = (p) => p, priceTooltip = () => null } = ctx;
 
     const div = document.createElement('div');
     div.className = 'item';
@@ -121,6 +121,15 @@ export function renderItemCard(item, ctx = {}) {
         mark.className = 'unstable-mark';
         mark.textContent = '!';
         price.appendChild(mark);
+    } else {
+        // Tier "+" / Owner's Choice explanation. Native title covers desktop
+        // hover and mobile long-press; the dotted underline hints it's tappable
+        // (tapping the card opens the modal, which has a tap-to-reveal tooltip).
+        const tip = priceTooltip(item.price);
+        if (tip) {
+            price.title = tip;
+            price.classList.add('has-tier-tooltip');
+        }
     }
 
     div.appendChild(price);

--- a/js/components/item-modal.js
+++ b/js/components/item-modal.js
@@ -1,5 +1,6 @@
 /* Split out of the old js/script.js (see git history). Loaded via js/core/bridge.js. */
 import { Utils } from '../core/utils.js';
+import { tooltipForPrice } from '../core/valueTiers.js';
 
 // ==================== PRICE GRAPH ====================
 const PriceGraph = {
@@ -875,15 +876,19 @@ class ItemModal {
             }
         }
 
+        // Tier "+" / Owner's Choice explanation — same tap-to-reveal pattern as
+        // the tax indicator, so it works on touch where hover doesn't exist.
+        const tierTip = item.unstable ? null : tooltipForPrice(item.price, this.catalog.taxMode);
+
         this.elements.price.innerHTML = `
-            <h2${item.unstable ? ' class="unstable" title="Unstable value — recently added or returned to Gamenight, so its price is volatile."' : ''}>${convertedPrice}${item.unstable ? '<span class="unstable-mark">!</span>' : ''}</h2>
+            <h2${item.unstable ? ' class="unstable" title="Unstable value — recently added or returned to Gamenight, so its price is volatile."' : ''}${tierTip ? ' class="has-tier-tooltip" onclick="event.stopPropagation(); this.classList.toggle(\'show-tooltip\')"' : ''}>${convertedPrice}${item.unstable ? '<span class="unstable-mark">!</span>' : ''}${tierTip ? `<span class="tax-tooltip tier-tooltip">${tierTip}</span>` : ''}</h2>
 
             ${this.catalog.taxMode !== 'nt' ? `
                 <span class="modal-tax-indicator" onclick="event.stopPropagation(); this.classList.toggle('show-tooltip')">
                     ${currentTax.short}
                     <span class="tax-tooltip">${currentTax.full}</span>
                 </span>
-                
+
             ` : ''}
             ${item.demand !== undefined && item.demand > 0 ? `<div class="modal-demand ${item.demand === 1 ? 'bad-demand' : item.demand === 2 ? 'okay-demand' : item.demand === 3 ? 'good-demand' : item.demand === 4 ? 'great-demand' : 'amazing-demand'}"><div class="demand-stars">${stars.join('')}</div></div>` : ''}
         `;

--- a/js/core/base-app.js
+++ b/js/core/base-app.js
@@ -2,6 +2,7 @@
 import { Utils } from './utils.js';
 import { ItemModal } from '../components/item-modal.js';
 import { renderItemCard, addItemBadges, fitItemName } from '../components/item-card.js';
+import { tierLabelForPrice, tooltipForPrice } from './valueTiers.js';
 
 // ==================== BASE APP CLASS ====================
 class BaseApp {
@@ -491,6 +492,7 @@ class BaseApp {
             wishlist: this.wishlist,
             favorites: this.favorites,
             convertPrice: (p) => this.convertPrice(p),
+            priceTooltip: (p) => this.priceTooltip(p),
             category: this.getItemCategory(item)
         });
     }
@@ -921,7 +923,7 @@ class BaseApp {
                     div.insertAdjacentHTML('beforeend', item.svg);
                 }
 
-                div.insertAdjacentHTML('beforeend', `${item.price != '' ? `<div class="item-price${item.unstable ? ' unstable' : ''}"${item.unstable ? ' title="Unstable value — recently added or returned to Gamenight, so its price is volatile."' : ''} style="${item.price == '0' ? 'opacity: 0; height: 16px;' : ''}">${this.convertPrice(Utils.formatPrice(item.price))}${item.unstable ? '<span class="unstable-mark">!</span>' : ''}</div>` : ''}`);
+                div.insertAdjacentHTML('beforeend', this.itemPriceHTML(item));
 
                 div.querySelector('.remove-wishlist').onclick = (e) => {
                     e.stopPropagation();
@@ -981,7 +983,7 @@ class BaseApp {
                     div.insertAdjacentHTML('beforeend', item.svg);
                 }
 
-                div.insertAdjacentHTML('beforeend', `${item.price != '' ? `<div class="item-price${item.unstable ? ' unstable' : ''}"${item.unstable ? ' title="Unstable value — recently added or returned to Gamenight, so its price is volatile."' : ''} style="${item.price == '0' ? 'opacity: 0; height: 16px;' : ''}">${this.convertPrice(Utils.formatPrice(item.price))}${item.unstable ? '<span class="unstable-mark">!</span>' : ''}</div>` : ''}`);
+                div.insertAdjacentHTML('beforeend', this.itemPriceHTML(item));
 
 
                 div.onclick = () => {
@@ -1016,7 +1018,16 @@ class BaseApp {
             const item = this.allItems.find(i => i.name === itemName);
             if (item) {
                 const priceEl = el.querySelector('.item-price');
-                if (priceEl) priceEl.textContent = this.convertPrice(item.price);
+                if (priceEl) {
+                    priceEl.textContent = this.convertPrice(item.price);
+                    if (!item.unstable) {
+                        // Tax can move an item across the tier floor, so refresh
+                        // the "+"/O-C tooltip to match the value now shown.
+                        const tip = this.priceTooltip(item.price);
+                        priceEl.classList.toggle('has-tier-tooltip', !!tip);
+                        if (tip) priceEl.title = tip; else priceEl.removeAttribute('title');
+                    }
+                }
             }
         });
 
@@ -1032,9 +1043,18 @@ class BaseApp {
     convertPrice(price) {
         if (!price || price.toLowerCase() === 'o/c') return price;
 
-        const str = String(price);
-        const hasPlus = str.includes('+');
-        const cleanStr = str.replace('+', '');
+        // Values >= 1000 display as a tier label derived from the raw stored
+        // value (single source of truth in valueTiers.js). Tax mode is applied
+        // to the value before the lookup so the tier tracks the tax the user is
+        // viewing. Anything below 1000 (or unparseable) falls through to the
+        // exact-value conversion below.
+        const tierLabel = tierLabelForPrice(price, this.taxMode);
+        if (tierLabel) return tierLabel;
+
+        // Below the tier floor: everything that reaches here is under 1000
+        // (values >= 1000 already returned a tier label above). Per the tier
+        // spec, sub-1000 values display the raw number with NO trailing "+".
+        const cleanStr = String(price).replace('+', '');
 
         const parseAndConvert = (priceStr) => {
             if (priceStr.includes('-')) {
@@ -1050,7 +1070,32 @@ class BaseApp {
             }
         };
 
-        return parseAndConvert(cleanStr) + (hasPlus ? '+' : '');
+        return parseAndConvert(cleanStr);
+    }
+
+    // Tooltip text for a stored price under the active tax mode: explains the
+    // tier "+" for numeric tiers, "Owner's Choice" for O/C, null otherwise.
+    priceTooltip(price) {
+        return tooltipForPrice(price, this.taxMode);
+    }
+
+    // Shared markup for an item's price chip (wishlist/list views). Renders the
+    // tier label via convertPrice and attaches the tier/O-C tooltip (or the
+    // unstable warning, which takes precedence) as a native title.
+    itemPriceHTML(item) {
+        if (item.price === '' || item.price == null) return '';
+        const hidden = item.price == '0' ? 'opacity: 0; height: 16px;' : '';
+        let cls = 'item-price';
+        let title = '';
+        if (item.unstable) {
+            cls += ' unstable';
+            title = ' title="Unstable value — recently added or returned to Gamenight, so its price is volatile."';
+        } else {
+            const tip = this.priceTooltip(item.price);
+            if (tip) { cls += ' has-tier-tooltip'; title = ` title="${tip}"`; }
+        }
+        const mark = item.unstable ? '<span class="unstable-mark">!</span>' : '';
+        return `<div class="${cls}"${title} style="${hidden}">${this.convertPrice(Utils.formatPrice(item.price))}${mark}</div>`;
     }
 
     parsePriceValue(str) {

--- a/js/core/bridge.js
+++ b/js/core/bridge.js
@@ -21,6 +21,7 @@ import { PopoverManager } from './popover-manager.js';
 import { api, ApiError } from './api.js';
 import { renderItemCard, addItemBadges, tradeItemHTML, itemVisualHTML, fitItemName } from '../components/item-card.js';
 import { openSurface } from '../components/surface.js';
+import * as ValueTiers from './valueTiers.js';
 
 // Globals first, so everything that runs later (inline page modules, classic
 // page scripts, DOMContentLoaded handlers, onclick=) can resolve them.
@@ -34,6 +35,8 @@ window.api = api;
 window.ApiError = ApiError;
 window.ItemCard = { renderItemCard, addItemBadges, tradeItemHTML, itemVisualHTML, fitItemName };
 window.openSurface = openSurface;
+// Value-tier system (single source of truth for tier labels/tooltips/legend).
+window.ValueTiers = ValueTiers;
 
 /* Page-agnostic global preferences (theme, price visibility, tax mode).
    These live in the shared profile-dropdown (rendered by Auth) whose buttons

--- a/js/core/layout.js
+++ b/js/core/layout.js
@@ -123,6 +123,7 @@ const Layout = {
 			<div class="footer-section">
 				<h4>Browse</h4>
 				<a href="/catalog">Catalog</a>
+				<a href="/value-tiers">Value Tiers (the “+”)</a>
 				<a href="/scammers">Scammers List</a>
 				<a href="/admin">Admin Portal</a>
 				<a href="/privacy-policy">Privacy Policy</a>

--- a/js/core/valueTiers.js
+++ b/js/core/valueTiers.js
@@ -1,0 +1,222 @@
+// valueTiers.js
+// Single source of truth for wiki value tiers.
+//
+// Each tier label already includes the trailing "+", which means the range is a
+// TYPICAL AVERAGE — an item can go higher in rare cases (e.g. "20-25K+" = "20–25K or more").
+// Do not strip the "+" or treat it as a separate numeric tier.
+//
+// Lookup rule: min is INCLUSIVE, max is EXCLUSIVE.
+// A raw value maps to a tier when: min <= value < max.
+// The top tier is open-ended (max: null) — anything >= 100000 maps there.
+// Values under 1000 get NO tier (display raw number, no "+").
+// O/C (Owner's Choice) is a separate flag, not a numeric tier.
+
+export const TIERS = [
+    { label: "1-1.5K+", min: 1000, max: 2000 },
+    { label: "2-2.5K+", min: 2000, max: 3000 },
+    { label: "3-4K+", min: 3000, max: 5000 },
+    { label: "5-6K+", min: 5000, max: 7000 },
+    { label: "7-8K+", min: 7000, max: 9000 },
+    { label: "9-10K+", min: 9000, max: 10000 },
+    { label: "10-12K+", min: 10000, max: 15000 },
+    { label: "15-17K+", min: 15000, max: 18000 },
+    { label: "18-20K+", min: 18000, max: 20000 },
+    { label: "20-25K+", min: 20000, max: 30000 },
+    { label: "30-35K+", min: 30000, max: 40000 },
+    { label: "40-45K+", min: 40000, max: 50000 },
+    { label: "50-55K+", min: 50000, max: 70000 },
+    { label: "70-100K+", min: 70000, max: 100000 },
+    { label: "100-130K+", min: 100000, max: null },
+];
+
+export const OWNERS_CHOICE_LABEL = "O/C";
+export const OWNERS_CHOICE_TOOLTIP = "Owner's Choice";
+
+// Tooltip explaining what the "+" means, for numeric tiers.
+export const TIER_TOOLTIP =
+    "Typical average range — rare items may be worth even more.";
+
+/**
+ * Returns the tier object for a raw numeric value, or null if under 1000.
+ * @param {number} value
+ * @returns {{label: string, min: number, max: number|null} | null}
+ */
+export function getTier(value) {
+    if (value == null || typeof value !== "number" || isNaN(value)) return null;
+    if (value < 1000) return null;
+    for (const tier of TIERS) {
+        const underMax = tier.max == null || value < tier.max;
+        if (value >= tier.min && underMax) return tier;
+    }
+    return null;
+}
+
+/**
+ * Formats a value for display in the wiki.
+ * - Owner's Choice items always return "O/C".
+ * - Values >= 1000 return the tier label (with its "+").
+ * - Values < 1000 return the raw number formatted, with no "+".
+ * - Null/missing (and not O/C) returns null so the caller can use its fallback.
+ * @param {number|null|undefined} value
+ * @param {boolean} [isOwnersChoice=false]
+ * @returns {string|null}
+ */
+export function formatValue(value, isOwnersChoice = false) {
+    if (isOwnersChoice) return OWNERS_CHOICE_LABEL;
+
+    const tier = getTier(value);
+    if (tier) return tier.label;
+
+    if (typeof value === "number" && !isNaN(value) && value > 0) {
+        return value.toLocaleString();
+    }
+    return null; // caller decides the fallback (e.g. "—" or "Unknown")
+}
+
+/**
+ * Returns the tooltip text for a given displayed value.
+ * @param {number|null|undefined} value
+ * @param {boolean} [isOwnersChoice=false]
+ * @returns {string|null}
+ */
+export function getTooltip(value, isOwnersChoice = false) {
+    if (isOwnersChoice) return OWNERS_CHOICE_TOOLTIP;
+    return getTier(value) ? TIER_TOOLTIP : null;
+}
+
+/* =============================================================================
+   Integration layer — bridges the tier system to the wiki's stored price data.
+
+   Prices in the catalogue are stored as free-form strings ("20000+", "10000-12000",
+   "20k", "O/C", "N/A", ""). These helpers turn a stored string into a single
+   representative numeric value so it can be binned into a tier, detect the
+   Owner's Choice flag from the string, and apply the active tax mode before the
+   lookup so tier labels stay consistent with the tax the user is viewing.
+   ========================================================================== */
+
+// Tax divisors, matching BaseApp.applyTax:
+//   'wt' (Shop Stand, 40% tax), 'gp' (Gamepass, 30% tax), anything else = flat.
+const TAX_DIVISORS = { wt: 0.6, gp: 0.7 };
+
+/**
+ * True when a stored price string represents an Owner's Choice item.
+ * @param {*} price
+ */
+export function isOwnersChoice(price) {
+    return String(price ?? "").trim().toLowerCase() === "o/c";
+}
+
+/**
+ * Parses a stored price string into a single representative numeric value used
+ * for tier lookup. Ranges resolve to their LOWER bound (inclusive-min rule, so
+ * "20000-30000" lands in the tier whose min is 20000). Handles "k"/"m" suffixes
+ * and a trailing "+". Returns null when there is no usable number (O/C, N/A, "",
+ * "0").
+ * @param {*} price
+ * @returns {number|null}
+ */
+export function parseRawValue(price) {
+    if (price == null) return null;
+    if (typeof price === "number") return isNaN(price) ? null : price;
+
+    let str = String(price).trim().toLowerCase();
+    if (!str || str === "n/a" || str === "o/c") return null;
+
+    str = str.replace("+", "").trim();
+    // Ranges ("20000-30000", "20k-25k") → lower bound.
+    if (/\d\s*-\s*\d/.test(str)) str = str.split("-")[0].trim();
+
+    let mult = 1;
+    if (str.endsWith("k")) { mult = 1000; str = str.slice(0, -1); }
+    else if (str.endsWith("m")) { mult = 1_000_000; str = str.slice(0, -1); }
+
+    const num = parseFloat(str);
+    if (isNaN(num)) return null;
+    const value = num * mult;
+    return value > 0 ? value : null;
+}
+
+/**
+ * Applies the active tax mode to a numeric value, matching BaseApp.applyTax.
+ * @param {number} value
+ * @param {string} [taxMode='nt']
+ */
+export function applyTax(value, taxMode = "nt") {
+    const div = TAX_DIVISORS[taxMode];
+    return div ? Math.round(value / div) : value;
+}
+
+/**
+ * The canonical display helper: given a stored price string and the active tax
+ * mode, returns the tier label (for values >= 1000), "O/C" for Owner's Choice,
+ * or null when the value doesn't map to a tier (under 1000, N/A, empty) so the
+ * caller can fall back to its existing exact-value rendering.
+ * @param {*} price
+ * @param {string} [taxMode='nt']
+ * @returns {string|null}
+ */
+export function tierLabelForPrice(price, taxMode = "nt") {
+    if (isOwnersChoice(price)) return OWNERS_CHOICE_LABEL;
+    const raw = parseRawValue(price);
+    if (raw == null) return null;
+    return getTier(applyTax(raw, taxMode))?.label ?? null;
+}
+
+/**
+ * The tooltip that accompanies a stored price's displayed value, or null when
+ * the value has no tooltip (under 1000, N/A, empty).
+ * @param {*} price
+ * @param {string} [taxMode='nt']
+ * @returns {string|null}
+ */
+export function tooltipForPrice(price, taxMode = "nt") {
+    if (isOwnersChoice(price)) return OWNERS_CHOICE_TOOLTIP;
+    const raw = parseRawValue(price);
+    if (raw == null) return null;
+    return getTier(applyTax(raw, taxMode)) ? TIER_TOOLTIP : null;
+}
+
+/* =============================================================================
+   Legend / reference component.
+
+   renderTierLegend() builds the full tier table plus the O/C row from the same
+   TIERS constant, so the "What does the + mean?" page can never drift from the
+   values the site actually uses. Returns an HTML string; styling lives in
+   css/value-tiers.css and rides on the shared design tokens.
+   ========================================================================== */
+
+/**
+ * Renders the tier reference table (all numeric tiers + the O/C row) as HTML.
+ * @returns {string}
+ */
+export function renderTierLegend() {
+    const fmt = (n) => (n == null ? "" : n.toLocaleString());
+
+    const rows = TIERS.map((t) => {
+        const range = t.max == null
+            ? `${fmt(t.min)}+`
+            : `${fmt(t.min)} – ${fmt(t.max - 1)}`;
+        return `
+            <tr>
+                <td><span class="tier-chip">${t.label}</span></td>
+                <td class="tier-range">${range}</td>
+            </tr>`;
+    }).join("");
+
+    return `
+        <table class="tier-legend-table">
+            <thead>
+                <tr>
+                    <th scope="col">Tier</th>
+                    <th scope="col">Typical value</th>
+                </tr>
+            </thead>
+            <tbody>
+                ${rows}
+                <tr class="tier-oc-row">
+                    <td><span class="tier-chip tier-chip-oc">${OWNERS_CHOICE_LABEL}</span></td>
+                    <td class="tier-range">${OWNERS_CHOICE_TOOLTIP} — no fixed value, set by the owner.</td>
+                </tr>
+            </tbody>
+        </table>`;
+}

--- a/js/nightly.js
+++ b/js/nightly.js
@@ -239,9 +239,15 @@ function createNewItem(item, color, list, date) {
     newItem.appendChild(untradable);
   }
 
-  // Price element
+  // Price element — tier label from the shared value-tier system when the
+  // value maps to one (>= 1K or O/C); raw value otherwise.
   const price = document.createElement("p");
-  price.innerHTML = `<img src="https://i.imgur.com/iZGLVYo.png" draggable="false">${item.price || 0}`;
+  const tierLabel = window.ValueTiers?.tierLabelForPrice?.(item.price);
+  if (tierLabel) {
+    const tip = window.ValueTiers.tooltipForPrice(item.price);
+    if (tip) price.title = tip;
+  }
+  price.innerHTML = `<img src="https://i.imgur.com/iZGLVYo.png" draggable="false">${tierLabel || item.price || 0}`;
   newItem.appendChild(price);
 
   // From element (hidden)

--- a/js/pages/profile.js
+++ b/js/pages/profile.js
@@ -555,7 +555,15 @@
                 if (item.price && item.price !== 'N/A' && item.price !== '0') {
                     const priceDiv = document.createElement('div');
                     priceDiv.className = 'item-price';
-                    priceDiv.textContent = this.convertPrice ? this.convertPrice(this.formatPrice(item.price)) : item.price;
+                    // Inherited BaseApp.convertPrice routes through the tier
+                    // system (valueTiers.js), so wishlist prices show the same
+                    // tier labels + tooltip as the catalog.
+                    priceDiv.textContent = this.convertPrice(String(item.price));
+                    const tierTip = this.priceTooltip(String(item.price));
+                    if (tierTip) {
+                        priceDiv.title = tierTip;
+                        priceDiv.classList.add('has-tier-tooltip');
+                    }
                     div.appendChild(priceDiv);
                 } else if (item.price === '0') {
                     const priceDiv = document.createElement('div');
@@ -588,20 +596,9 @@
             }
         }
 
-        formatPrice(price) {
-            if (!price || price === 'N/A') return 'N/A';
-            return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-        }
-
-        convertPrice(price) {
-            if (!price || price === 'N/A') return 'N/A';
-            // Convert to abbreviated format if needed (e.g., 1000 -> 1K)
-            const num = parseFloat(price.replace(/,/g, ''));
-            if (isNaN(num)) return price;
-            if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M';
-            if (num >= 1000) return (num / 1000).toFixed(1) + 'K';
-            return num.toString();
-        }
+        // NOTE: price formatting/conversion is inherited from BaseApp, which
+        // routes every value through the tier system (js/core/valueTiers.js).
+        // Do not re-implement convertPrice here — hand-rolled labels drift.
 
         renderReviews(reviews) {
             const container = document.getElementById('reviews-container');

--- a/js/trading.js
+++ b/js/trading.js
@@ -211,17 +211,23 @@ class TradingHub {
         return this.itemsByName.get(String(name).toLowerCase())?.category || null;
     }
 
-    // Catalog value for an item name, formatted for the hover tooltip. Returns
-    // null when the item has no known/priced value (unrated, N/A, O/C, or 0) so
-    // the tooltip just shows the name.
+    // Catalog value for an item name, formatted for the hover tooltip. Values
+    // >= 1K show their tier label and O/C shows as-is (window.ValueTiers is the
+    // single source of truth). Returns null when the item has no known/priced
+    // value (unrated, N/A, or 0) so the tooltip just shows the name.
     priceFor(name) {
         if (!name || !this.itemsByName) return null;
         const raw = this.itemsByName.get(String(name).toLowerCase())?.price;
         if (raw === null || raw === undefined) return null;
         const s = String(raw).trim();
         if (!s || s === '0') return null;
-        const upper = s.toUpperCase();
-        if (upper === 'N/A' || upper === 'O/C') return null;
+        if (s.toUpperCase() === 'N/A') return null;
+        if (window.ValueTiers?.isOwnersChoice?.(s)) {
+            return `${window.ValueTiers.OWNERS_CHOICE_LABEL} — ${window.ValueTiers.OWNERS_CHOICE_TOOLTIP}`;
+        }
+        if (s.toUpperCase() === 'O/C') return null; // ValueTiers missing (shouldn't happen)
+        const tierLabel = window.ValueTiers?.tierLabelForPrice?.(s);
+        if (tierLabel) return `${tierLabel} value`;
         const formatted = window.Utils.formatPrice(raw);
         return formatted ? `${formatted} value` : null;
     }

--- a/value-tiers.html
+++ b/value-tiers.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-LJ02XLZ4KJ"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-LJ02XLZ4KJ');
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>What does the + mean? - EM Wiki</title>
+    <meta name="description" content="How EM Wiki value tiers work — what the + after a value means, the full tier table, and O/C (Owner's Choice) explained.">
+    <meta property="og:title" content="What does the + mean? - EM Wiki">
+    <meta property="og:image" content="https://emwiki.com/imgs/QgWIUWf.png">
+    <meta property="og:description" content="How EM Wiki value tiers work — what the + after a value means, the full tier table, and O/C (Owner's Choice) explained.">
+    <link rel="icon" href="./imgs/favicon.png" type="image/png">
+    <link rel="apple-touch-icon" href="./imgs/app.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <meta name="theme-color" content="#0e1116">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="stylesheet" href="./css/style.css?v=2.2.2">
+    <link rel="stylesheet" href="./css/value-tiers.css">
+</head>
+
+<body>
+    <div id="site-header"></div>
+
+    <main class="tiers-page">
+        <h1>What does the “+” mean?</h1>
+        <p class="tiers-intro">
+            Item values on the wiki display as <strong>tiers</strong> — typical value bands like
+            <span style="white-space: nowrap;"><span class="tier-chip">20-25K+</span>.</span>
+            The trailing <strong>+</strong> means the range is the
+            <strong>average</strong>: an item can go higher in rare cases, so read it as
+            “20–25K <em>or more</em>,” not a hard cap.
+        </p>
+
+        <div class="tiers-card">
+            <h2>How tiers work</h2>
+            <p>Every item's tier is derived from its raw stored value — a value maps to the tier whose
+                range contains it. Only values of <strong>1K and above</strong> get a tier; anything under
+                1K shows its exact value with no “+”.</p>
+            <p>The top tier is open-ended: anything worth 100K or more lands in
+                <span class="tier-chip">100-130K+</span>, consistent with the “+” meaning it can exceed the
+                stated range.</p>
+        </div>
+
+        <div class="tiers-card">
+            <h2>Tier table</h2>
+            <div id="tier-legend"><!-- filled by ValueTiers.renderTierLegend() --></div>
+        </div>
+
+        <div class="tiers-card">
+            <h2>O/C — Owner's Choice</h2>
+            <p><span class="tier-chip tier-chip-oc">O/C</span> items have <strong>no fixed value</strong>:
+                the owner decides what they're worth in a trade. O/C is a separate flag, not a numeric
+                tier — an item marked O/C always displays “O/C” regardless of any stored value.</p>
+        </div>
+    </main>
+
+    <div id="site-footer"></div>
+
+    <script type="module" src="./js/core/bridge.js"></script>
+    <script type="module">
+        import { renderTierLegend } from './js/core/valueTiers.js';
+        document.getElementById('tier-legend').innerHTML = renderTierLegend();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
Introduces a centralized value tier system that replaces ad-hoc price formatting with consistent tier labels (e.g., "20-25K+") across the wiki. The "+" now has a documented meaning: it indicates a typical average range, not a hard cap. Items worth 1K+ display tier labels; items under 1K show exact values with no "+". Owner's Choice (O/C) is a separate flag with its own label.

## Key Changes

- **New `js/core/valueTiers.js`**: Single source of truth for all 15 numeric tiers plus O/C. Exports:
  - `TIERS` constant with min/max ranges (inclusive min, exclusive max)
  - `getTier(value)` — maps a numeric value to its tier object
  - `formatValue(value, isOwnersChoice)` — formats for display
  - `getTooltip(value, isOwnersChoice)` — returns explanation text
  - Integration layer: `parseRawValue()`, `applyTax()`, `tierLabelForPrice()`, `tooltipForPrice()` — bridge stored price strings to tier lookup, applying tax mode before lookup so tier labels stay consistent with what the user is viewing
  - `renderTierLegend()` — generates the full tier reference table as HTML

- **New `value-tiers.html` page**: "What does the + mean?" documentation page with:
  - Explanation of tier ranges and the "+" meaning
  - Full tier table rendered from `TIERS` constant (never drifts from actual values)
  - O/C explanation
  - Styled with glassy clay cards matching the site design

- **New `css/value-tiers.css`**: Styles for the tier legend table, tier chips (with robux icon), and O/C chip (gold accent, no icon)

- **`js/core/base-app.js`**: 
  - `convertPrice()` now routes values ≥1K through `tierLabelForPrice()` to get tier labels; sub-1K values display exact numbers with no "+"
  - New `priceTooltip()` method returns tier explanation or O/C tooltip
  - New `itemPriceHTML()` helper generates price chip markup with tier tooltip support
  - Tax mode changes now refresh tier tooltips on the fly (tax can move items across tier boundaries)

- **`js/components/item-card.js`**: Accepts `priceTooltip` callback in context; renders native `title` attribute on price chips for tier/O/C explanations

- **`js/components/item-modal.js`**: Adds tier tooltip to modal price display with tap-to-reveal pattern (same as tax indicator)

- **`js/pages/profile.js`**: Wishlist prices now inherit `convertPrice()` and `priceTooltip()` from BaseApp, so they display tier labels and tooltips consistently with the catalog

- **`js/trading.js`**: `priceFor()` now uses `window.ValueTiers.isOwnersChoice()` and `tierLabelForPrice()` for consistent O/C and tier label rendering in hover tooltips

- **`js/nightly.js`**: Nightly list prices now display tier labels via `window.ValueTiers.tierLabelForPrice()`

- **`css/style.css`**: Added `.item-price.has-tier-tooltip` with `cursor: help` to hint the tooltip

- **`css/modal.css`**: Tier tooltip styling for modal price (white-space: normal, max-width, tap-to-reveal animation)

- **`js/core/layout.js`**: Added footer link to `/value-tiers` page

- **`js/core/bridge.js`**: Exports `ValueTiers` to `window` so all pages can access the tier system

## Notable Implementation Details

- **Tax-aware tier lookup**: `applyTax()` is called before `getTier()`, so a value's tier label always matches the tax mode the user is viewing. Switching tax modes updates tier labels and tooltips in real time.
- **Range resolution**: Stored price ranges (e.g., "20000-30000") resolve to their

https://claude.ai/code/session_01TFbUxT5dN12RE84T5yDD7d